### PR TITLE
Bugfix/230 home page how it works send request

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -50,7 +50,7 @@
       },
       "sendRequest": {
         "title": "Send Request",
-        "description": "Write a request to the tutor in two clicks, where you indicate/confirm the price and the desired level of training."
+        "description": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout."
       },
       "startLearning": {
         "title": "Start Learning",


### PR DESCRIPTION
Closes #230

Issue resolved.

What was fixed:
- The “Send a Request” item in the home page “How it works” block, including the student registration option, now matches the mockup. 

Steps verified:
1. Opened the site.  
2. Clicked on the “How it works” button on the home page header.  
3. Checked the “How it works” block on the home page.  

Actual result now:
The “Send a Request” item matches the mockup as expected.
