### PR TITLE
feat(frontend): use Google Identity credential with new /auth/google-auth endpoint (#240)

### DIFF
--- a/src/containers/guest-home-page/google-button/GoogleButton.jsx
+++ b/src/containers/guest-home-page/google-button/GoogleButton.jsx
@@ -18,9 +18,9 @@ const GoogleButton = ({ role, route, buttonWidth, type }) => {
   const [googleAuth] = useGoogleAuthMutation()
 
   const handleCredentialResponse = useCallback(
-    async (token) => {
+    async (response) => {
       try {
-        await googleAuth({ token, role }).unwrap()
+        await googleAuth({ token: response.credential, role }).unwrap()
         closeModal()
       } catch (e) {
         setAlert({

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -74,9 +74,5 @@ export const authService = appApi.injectEndpoints({
   })
 })
 
-export const {
-  useSignUpMutation,
-  useLoginMutation,
-  useGoogleAuthMutation,
-  useLogoutMutation
-} = authService
+export const { useLoginMutation, useGoogleAuthMutation, useLogoutMutation } =
+  authService


### PR DESCRIPTION
Update Google OAuth integration to use the new backend endpoint

### Changes
- Use `response.credential` from Google Identity as JWT token.
- Send `{ token: response.credential }` in POST request.

**Dependencies**
- Depends on backend PR #38
