### PR TITLE
fix: #232 disable login button when email or password fields are empty

### DIFF
--- a/src/containers/guest-home-page/login-form/LoginForm.jsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.jsx
@@ -71,7 +71,7 @@ const LoginForm = ({
       </Typography>
 
       <AppButton
-        disabled={!data.email || !data.password}
+        disabled={!data.email || !data.password || !!errors.email}
         loading={authLoading}
         sx={styles.loginButton}
         type='submit'

--- a/src/containers/guest-home-page/login-form/LoginForm.jsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.jsx
@@ -70,7 +70,12 @@ const LoginForm = ({
         {t('login.forgotPassword')}
       </Typography>
 
-      <AppButton loading={authLoading} sx={styles.loginButton} type='submit'>
+      <AppButton
+        disabled={!data.email || !data.password}
+        loading={authLoading}
+        sx={styles.loginButton}
+        type='submit'
+      >
         {t('common.labels.login')}
       </AppButton>
     </Box>


### PR DESCRIPTION
- Added disabled prop to AppButton that checks if email or password are empty
- Login button now only becomes clickable when both fields contain data
- Prevents form submission with incomplete credentials
- Resolves issue where login button was clickable without entering any data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The login submit button is now disabled until both email and password are provided and the email passes validation, preventing accidental submissions with incomplete or invalid credentials.
  * The button continues to stay disabled during loading to avoid duplicate submissions.
  * Improves clarity and reduces errors during sign-in by providing a consistent disabled state and clearer user feedback when inputs are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->