### PR TITLE
fix: #10 enable modal closing on close (x) button click

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -7,6 +7,7 @@ import { PaperProps } from '@mui/material'
 
 import useBreakpoints from '~/hooks/use-breakpoints'
 import { styles } from '~/components/popup-dialog/PopupDialog.styles'
+import { useModalContext } from '~/context/modal-context'
 
 interface PopupDialogProps {
   content: React.ReactNode
@@ -22,6 +23,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
   closeModalAfterDelay
 }) => {
   const { isMobile } = useBreakpoints()
+  const { closeModal } = useModalContext()
 
   const handleMouseOver = () => timerId && clearTimeout(timerId)
   const handleMouseLeave = () => timerId && closeModalAfterDelay()
@@ -41,7 +43,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
         onMouseOver={handleMouseOver}
         sx={styles.box}
       >
-        <IconButton sx={styles.icon}>
+        <IconButton onClick={closeModal} sx={styles.icon}>
           <CloseIcon />
         </IconButton>
         <Box sx={styles.contentWraper}>{content}</Box>

--- a/src/tests/unit/components/popup-dialog/PopupDialog.spec.jsx
+++ b/src/tests/unit/components/popup-dialog/PopupDialog.spec.jsx
@@ -1,7 +1,14 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within
+} from '@testing-library/react'
 import { vi } from 'vitest'
 
 import PopupDialog from '~/components/popup-dialog/PopupDialog'
+import useBreakpoints from '~/hooks/use-breakpoints'
 
 const closeModal = vi.fn()
 const closeModalAfterDelay = vi.fn()
@@ -21,43 +28,58 @@ vi.mock('~/hooks/use-confirm', () => {
   }
 })
 
+vi.mock('~/hooks/use-breakpoints', () => ({
+  default: vi.fn(() => ({ isMobile: false }))
+}))
+
 vi.mock('~/context/modal-context', () => ({
   useModalContext: () => ({
     closeModal
   })
 }))
+const renderPopup = (customProps = {}) =>
+  render(<PopupDialog {...props} {...customProps} />)
 
 describe('Popup dialog test', () => {
   beforeEach(() => {
-    render(<PopupDialog {...props} />)
+    vi.clearAllMocks()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('should have content text', () => {
+    renderPopup()
     const content = screen.getByText(props.content)
-
     expect(content).toBeInTheDocument()
   })
 
   it('should close modal when X button is clicked', () => {
+    renderPopup()
     const closeButton = screen.getByRole('button')
     fireEvent.click(closeButton)
 
     expect(closeModal).toHaveBeenCalledTimes(1)
   })
-})
-
-describe('Popup dialog test with timerId', () => {
-  const propsWithTimerId = { ...props, timerId: 21 }
-  beforeEach(() => {
-    render(<PopupDialog {...propsWithTimerId} />)
-  })
 
   it('should close popup after delay', async () => {
-    const popupContent = screen.getByTestId('popupContent')
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+    renderPopup({ timerId: 21 })
+
+    const dialog = screen.getByTestId('popup')
+    const popupContent = within(dialog).getByTestId('popupContent')
 
     fireEvent.mouseEnter(popupContent)
     fireEvent.mouseLeave(popupContent)
 
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(21)
     await waitFor(() => expect(closeModalAfterDelay).toHaveBeenCalled())
+  })
+
+  it('should render fullscreen when isMobile is true', () => {
+    useBreakpoints.mockReturnValue({ isMobile: true })
+    renderPopup()
+    const dialog = screen.getByTestId('popup')
+    expect(dialog).toBeInTheDocument()
   })
 })

--- a/src/tests/unit/components/popup-dialog/PopupDialog.spec.jsx
+++ b/src/tests/unit/components/popup-dialog/PopupDialog.spec.jsx
@@ -76,6 +76,18 @@ describe('Popup dialog test', () => {
     await waitFor(() => expect(closeModalAfterDelay).toHaveBeenCalled())
   })
 
+  it('should not call clearTimeout when timerId is null', () => {
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout')
+    renderPopup({ timerId: null })
+
+    const dialog = screen.getByTestId('popup')
+    const popupContent = within(dialog).getByTestId('popupContent')
+
+    fireEvent.mouseEnter(popupContent)
+
+    expect(clearTimeoutSpy).not.toHaveBeenCalled()
+  })
+
   it('should render fullscreen when isMobile is true', () => {
     useBreakpoints.mockReturnValue({ isMobile: true })
     renderPopup()

--- a/src/tests/unit/components/popup-dialog/PopupDialog.spec.jsx
+++ b/src/tests/unit/components/popup-dialog/PopupDialog.spec.jsx
@@ -9,7 +9,6 @@ const setFullScreen = vi.fn()
 
 const props = {
   content: 'test',
-  closeModal,
   closeModalAfterDelay,
   timerId: null,
   isFullScreen: true,
@@ -22,6 +21,12 @@ vi.mock('~/hooks/use-confirm', () => {
   }
 })
 
+vi.mock('~/context/modal-context', () => ({
+  useModalContext: () => ({
+    closeModal
+  })
+}))
+
 describe('Popup dialog test', () => {
   beforeEach(() => {
     render(<PopupDialog {...props} />)
@@ -31,6 +36,13 @@ describe('Popup dialog test', () => {
     const content = screen.getByText(props.content)
 
     expect(content).toBeInTheDocument()
+  })
+
+  it('should close modal when X button is clicked', () => {
+    const closeButton = screen.getByRole('button')
+    fireEvent.click(closeButton)
+
+    expect(closeModal).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
### Description
Added the ability to close the modal when clicking the close button.

### Changes
- imported `useModalContext` to `PopupDialog`
- extracted `closeModal` from the modal context
- added `onClick={closeModal}` handler to the close button

### How to test
- Open the Login popup.
- Click on the close (X) button in the popup window.
- Verify that the modal closes

### Issue
Closes #10