### PR TITLE
fix: #237 update 'generalInfo' page description in Become a student pop-up

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -1,6 +1,6 @@
 {
   "generalInfo": {
-    "title": "Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint.",
+    "title": "Please complete the registration form for the best possible experience.",
     "textFieldLabel": "Describe in short your professional status",
     "helperText": "Inputs with the * sign are required"
   },

--- a/src/constants/translations/ua/become-tutor.json
+++ b/src/constants/translations/ua/become-tutor.json
@@ -6,7 +6,7 @@
     "photo": "Фото"
   },
   "generalInfo": {
-    "title": "Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint.",
+    "title": "Будь ласка, заповніть форму реєстрації для найкращого досвіду.",
     "textFieldLabel": "Коротко опишіть свій професійний статус",
     "helperText": "Поля зі знаком * є обов'язковими"
   },


### PR DESCRIPTION
Description:
Fixed bug #237 — updated the description in the “General” step of the ‘Become a student’ pop-up to match the mockup.

Changes:
Replaced placeholder text (Amet minim mollit non deserunt ullamco est sit aliqua dolor do amet sint.) with the real text.
EN: Please complete the registration form for the best possible experience.
UA: Будь ласка, заповніть форму реєстрації для найкращого досвіду.

Files updated:
src/constants/translations/en/become-tutor.json
src/constants/translations/ua/become-tutor.json

This ensures that the pop-up description now matches the design mockup for users with the Tutor role.