### PR TITLE
fix: #238 update 'Photo' page description in Become a student pop-up

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -24,7 +24,7 @@
     "imageAlt": "Your photo",
     "button": "Upload your profile photo",
     "placeholder": "Photo Preview",
-    "description": "Velit officia consequat duis enim velit mollit. Exercitation veniam consequat sunt nostrud amet.",
+    "description": "Please upload a photo that represents you and helps others recognize you.",
     "typeError": "Wrong file type. Only .png/.jpg/.jpeg files are allowed.",
     "fileSizeError": "Size for one file cannot be more than 10MB."
   },

--- a/src/constants/translations/ua/become-tutor.json
+++ b/src/constants/translations/ua/become-tutor.json
@@ -30,7 +30,7 @@
 	"imageAlt": "Ваша фотографія",
 	"button": "Завантажте свою фотографію профілю",
 	"placeholder":"Попередній перегляд фотографій",
-	"description":"Velit officia consequat duis enim velit mollit. Exercitation veniam consequat sunt nostrud amet.",
+	"description":"Будь ласка, завантажте фото, яке представляє вас і допоможе іншим впізнати вас.",
 	"typeError": "Неправильний тип файлу. Дозволяються лише файли .png/.jpg/.jpeg.",
 	"fileSizeError": "Розмір одного файлу не може перевищувати 10 Мб."
   },


### PR DESCRIPTION
Fixed bug #238 - updated the description in the “Photo” step of the ‘Become a student’ pop-up to match the mockup. The issue affected users with the Tutor role. Changes applied in both EN and UA translations.

Changes:
Replaced placeholder text (Velit officia consequat duis enim velit mollit…) with the real text.
EN: Please upload a photo that represents you and helps others recognize you.
UA: Будь ласка, завантажте фото, яке представляє вас і допоможе іншим впізнати вас.

Files updated:
src/constants/translations/en/become-tutor.json
src/constants/translations/ua/become-tutor.json