### PR TITLE
test: #49 add test for content switcher component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ test-report.xml
 # misc
 /.idea
 .idea
+/.vscode
+.vscode
 .DS_Store
 .env.local
 .env.development.local

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "editor.formatOnSave": false,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
-}

--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -14,25 +14,11 @@ const switchOptions = {
   }
 }
 
+const user = userEvent.setup()
+const handleChange = vi.fn()
+
 describe('AppContentSwitcher', () => {
-  it('should render with the correct props', () => {
-    render(
-      <AppContentSwitcher
-        active
-        onChange={() => {}}
-        switchOptions={switchOptions}
-        typographyVariant='body1'
-      />
-    )
-
-    expect(screen.getByText('Left Option')).toBeInTheDocument()
-    expect(screen.getByText('Right Option')).toBeInTheDocument()
-    expect(screen.getByTestId('switch')).toBeInTheDocument()
-  })
-
-  it('should call the onChange function when the switch is clicked', async () => {
-    const user = userEvent.setup()
-    const handleChange = vi.fn()
+  beforeEach(() => {
     render(
       <AppContentSwitcher
         active
@@ -41,7 +27,15 @@ describe('AppContentSwitcher', () => {
         typographyVariant='body1'
       />
     )
+  })
 
+  it('should render with the correct props', () => {
+    expect(screen.getByText('Left Option')).toBeInTheDocument()
+    expect(screen.getByText('Right Option')).toBeInTheDocument()
+    expect(screen.getByTestId('switch')).toBeInTheDocument()
+  })
+
+  it('should call the onChange function when the switch is clicked', async () => {
     const switchElement = screen.getByRole('checkbox')
     await user.click(switchElement)
 
@@ -49,16 +43,6 @@ describe('AppContentSwitcher', () => {
   })
 
   it('should renders tooltips when tooltip props are passed', async () => {
-    const user = userEvent.setup()
-    render(
-      <AppContentSwitcher
-        active
-        onChange={() => {}}
-        switchOptions={switchOptions}
-        typographyVariant='body1'
-      />
-    )
-
     await user.hover(screen.getByText('Left Option'))
     expect(await screen.findByText('Left Tooltip')).toBeInTheDocument()
 

--- a/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/src/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { it, vi } from 'vitest'
+import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
+
+const switchOptions = {
+  left: {
+    text: 'Left Option',
+    tooltip: 'Left Tooltip'
+  },
+  right: {
+    text: 'Right Option',
+    tooltip: 'Right Tooltip'
+  }
+}
+
+describe('AppContentSwitcher', () => {
+  it('should render with the correct props', () => {
+    render(
+      <AppContentSwitcher
+        active
+        onChange={() => {}}
+        switchOptions={switchOptions}
+        typographyVariant='body1'
+      />
+    )
+
+    expect(screen.getByText('Left Option')).toBeInTheDocument()
+    expect(screen.getByText('Right Option')).toBeInTheDocument()
+    expect(screen.getByTestId('switch')).toBeInTheDocument()
+  })
+
+  it('should call the onChange function when the switch is clicked', async () => {
+    const user = userEvent.setup()
+    const handleChange = vi.fn()
+    render(
+      <AppContentSwitcher
+        active
+        onChange={handleChange}
+        switchOptions={switchOptions}
+        typographyVariant='body1'
+      />
+    )
+
+    const switchElement = screen.getByRole('checkbox')
+    await user.click(switchElement)
+
+    expect(handleChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('should renders tooltips when tooltip props are passed', async () => {
+    const user = userEvent.setup()
+    render(
+      <AppContentSwitcher
+        active
+        onChange={() => {}}
+        switchOptions={switchOptions}
+        typographyVariant='body1'
+      />
+    )
+
+    await user.hover(screen.getByText('Left Option'))
+    expect(await screen.findByText('Left Tooltip')).toBeInTheDocument()
+
+    await user.unhover(screen.getByText('Left Option'))
+    expect(screen.getByText('Left Tooltip')).not.toBeVisible()
+
+    await user.hover(screen.getByText('Right Option'))
+    expect(await screen.findByText('Right Tooltip')).toBeInTheDocument()
+
+    await user.unhover(screen.getByText('Right Option'))
+    expect(screen.getByText('Right Tooltip')).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
Added unit tests for the `AppContentSwitcher` component.

Test cases included:

- it should render with the correct props
- it should call the onChange function when the switch is clicked
- it should renders tooltips when tooltip props are passed

Related to [(SP: 1) Write tests for content switcher component #49](https://github.com/Space2Study-UA-4427-4288-01/Issues/issues/49)