### PR TITLE
fix: #233 fix text below 'Sign Up with Google' button

### DIFF
--- a/src/constants/translations/en/signup.json
+++ b/src/constants/translations/en/signup.json
@@ -7,8 +7,8 @@
   "and": "and",
   "googleButton": "Sign up with Google",
   "continue": "or continue",
-  "haveAccount": "Already have a tutor account?",
-  "joinUs": "Login!",
+  "haveAccount": "Already have a Space2Study account?",
+  "joinUs": "Log In!",
   "confirmEmailTitle": "Your email address needs to be verified",
   "confirmEmailMessage": "We sent a confirmation email to: ",
   "confirmEmailDesc": " Check your email and click on the confirmation button to continue."


### PR DESCRIPTION
**Description:**
Updated the text under the "Sign Up with Google" button in the "Tutor Sign Up" pop-up to match the design mockup. Previously it displayed "Already have a tutor account? Login!", which did not correspond to the requirements. Now it correctly shows "Already have a Space2Study account? Log In!".

**Changes:**
Updated src/constants/translations/en/signup.json with the correct English text.
