### PR TITLE
fix: #236 change become a student pop up the placeholder text (en/ua)

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -13,7 +13,7 @@
     "autocompleteLabel": "Your native language"
   },
   "categories": {
-    "title": "Velit officia consequat duis enim velit mollit. Other categories you can add in your account settings later.",
+    "title": "Please choose the main subjects based on the category. You can add others later.",
     "mainSubjectsLabel": "Main Tutoring Category",
     "subjectLabel": "Subject",
     "btnText": "Add one more subject",

--- a/src/constants/translations/ua/become-tutor.json
+++ b/src/constants/translations/ua/become-tutor.json
@@ -19,7 +19,7 @@
     "autocompleteLabel": "Твоя рідна мова"
   },
   "categories": {
-    "title": "Velit officia consequat duis enim velit mollit. Other categories you can add in your account settings later.",
+    "title": "Будь ласка, оберіть основні предмети відповідно до категорії. Інші можна буде додати пізніше.",
     "mainSubjectsLabel": "Основна категорія предмету",
     "subjectLabel": "Предмет",
     "btnText": "Додайте ще один предмет",


### PR DESCRIPTION
Description
Fixed the description in the “Interests” page on the ‘Become a student’ pop-up. Replaced lorem ipsum text with the correct English and Ukrainian versions.

Changes
Updated `become-tutor.json` for both `English` and `Ukrainian` versions.

Issue
Closes https://github.com/Space2Study-UA-4427-4288-01/Issues/issues/236