### PR TITLE
test: #54 add tests for search autocomplete component

### DIFF
--- a/src/tests/unit/components/search-autocomplete/SearchAutocomplete.spec.jsx
+++ b/src/tests/unit/components/search-autocomplete/SearchAutocomplete.spec.jsx
@@ -17,117 +17,68 @@ describe('SearchAutocomplete', () => {
     'Student: Bob Brown'
   ]
 
+  const renderSearchAutocomplete = (props = {}) =>
+    renderWithProviders(
+      <SearchAutocomplete
+        onSearchChange={mockOnSearchChange}
+        options={options}
+        search=''
+        setSearch={mockSetSearch}
+        textFieldProps={textFieldProps}
+        {...props}
+      />
+    )
+
   beforeEach(() => {
     mockSetSearch.mockClear()
     mockOnSearchChange.mockClear()
   })
 
   it('renders autocomplete with search input', () => {
-    renderWithProviders(
-      <SearchAutocomplete
-        onSearchChange={mockOnSearchChange}
-        options={options}
-        search=''
-        setSearch={mockSetSearch}
-        textFieldProps={textFieldProps}
-      />
-    )
-
-    const input = screen.getByLabelText('Search')
-    expect(input).toBeInTheDocument()
+    renderSearchAutocomplete()
+    expect(screen.getByLabelText('Search')).toBeInTheDocument()
   })
 
   it('updates search input on typing', async () => {
-    renderWithProviders(
-      <SearchAutocomplete
-        onSearchChange={mockOnSearchChange}
-        options={options}
-        search=''
-        setSearch={mockSetSearch}
-        textFieldProps={textFieldProps}
-      />
-    )
-
+    renderSearchAutocomplete()
     const input = screen.getByLabelText('Search')
     await userEvent.type(input, 'Tutor: John')
-
     expect(input.value).toBe('Tutor: John')
   })
 
   it('filters options on typing', async () => {
-    renderWithProviders(
-      <SearchAutocomplete
-        onSearchChange={mockOnSearchChange}
-        options={options}
-        search=''
-        setSearch={mockSetSearch}
-        textFieldProps={textFieldProps}
-      />
-    )
-
+    renderSearchAutocomplete()
     const input = screen.getByLabelText('Search')
     await userEvent.type(input, 'Alice')
-
-    const option = await screen.findByText('Student: Alice Johnson')
-    expect(option).toBeInTheDocument()
+    expect(
+      await screen.findByText('Student: Alice Johnson')
+    ).toBeInTheDocument()
   })
 
   it('selects an option on click', async () => {
-    renderWithProviders(
-      <SearchAutocomplete
-        onSearchChange={mockOnSearchChange}
-        options={options}
-        search=''
-        setSearch={mockSetSearch}
-        textFieldProps={textFieldProps}
-      />
-    )
-
+    renderSearchAutocomplete()
     const input = screen.getByLabelText('Search')
     await userEvent.type(input, 'Jane')
-
     const option = await screen.findByText('Tutor: Jane Smith')
     await userEvent.click(option)
-
     expect(mockSetSearch).toHaveBeenCalledWith('Tutor: Jane Smith')
     expect(mockOnSearchChange).toHaveBeenCalled()
   })
 
   it('clears search input on clear icon click', async () => {
-    renderWithProviders(
-      <SearchAutocomplete
-        onSearchChange={mockOnSearchChange}
-        options={options}
-        search='Tutor: John Doe'
-        setSearch={mockSetSearch}
-        textFieldProps={textFieldProps}
-      />
-    )
-
+    renderSearchAutocomplete({ search: 'Tutor: John Doe' })
     const clearButton = screen.getByTestId('ClearIcon').closest('button')
     await userEvent.click(clearButton)
-
     expect(mockSetSearch).toHaveBeenCalledWith('')
     expect(mockOnSearchChange).toHaveBeenCalled()
   })
 
   it('triggers search on search button click', async () => {
-    renderWithProviders(
-      <SearchAutocomplete
-        onSearchChange={mockOnSearchChange}
-        options={options}
-        search=''
-        setSearch={mockSetSearch}
-        textFieldProps={textFieldProps}
-      />
-    )
-
+    renderSearchAutocomplete()
     const input = screen.getByLabelText('Search')
     await userEvent.type(input, 'Bob')
-
     const searchButton = screen.getByRole('button', { name: /search/i })
     await userEvent.click(searchButton)
-
     expect(mockSetSearch).toHaveBeenCalledWith('Bob')
     expect(mockOnSearchChange).toHaveBeenCalled()
   })

--- a/src/tests/unit/components/search-autocomplete/SearchAutocomplete.spec.jsx
+++ b/src/tests/unit/components/search-autocomplete/SearchAutocomplete.spec.jsx
@@ -1,0 +1,134 @@
+import { vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import SearchAutocomplete from '~/components/search-autocomplete/SearchAutocomplete'
+import { renderWithProviders } from '~tests/test-utils'
+
+describe('SearchAutocomplete', () => {
+  const mockSetSearch = vi.fn()
+  const mockOnSearchChange = vi.fn()
+  const textFieldProps = { label: 'Search' }
+
+  const options = [
+    'Tutor: John Doe',
+    'Tutor: Jane Smith',
+    'Student: Alice Johnson',
+    'Student: Bob Brown'
+  ]
+
+  beforeEach(() => {
+    mockSetSearch.mockClear()
+    mockOnSearchChange.mockClear()
+  })
+
+  it('renders autocomplete with search input', () => {
+    renderWithProviders(
+      <SearchAutocomplete
+        onSearchChange={mockOnSearchChange}
+        options={options}
+        search=''
+        setSearch={mockSetSearch}
+        textFieldProps={textFieldProps}
+      />
+    )
+
+    const input = screen.getByLabelText('Search')
+    expect(input).toBeInTheDocument()
+  })
+
+  it('updates search input on typing', async () => {
+    renderWithProviders(
+      <SearchAutocomplete
+        onSearchChange={mockOnSearchChange}
+        options={options}
+        search=''
+        setSearch={mockSetSearch}
+        textFieldProps={textFieldProps}
+      />
+    )
+
+    const input = screen.getByLabelText('Search')
+    await userEvent.type(input, 'Tutor: John')
+
+    expect(input.value).toBe('Tutor: John')
+  })
+
+  it('filters options on typing', async () => {
+    renderWithProviders(
+      <SearchAutocomplete
+        onSearchChange={mockOnSearchChange}
+        options={options}
+        search=''
+        setSearch={mockSetSearch}
+        textFieldProps={textFieldProps}
+      />
+    )
+
+    const input = screen.getByLabelText('Search')
+    await userEvent.type(input, 'Alice')
+
+    const option = await screen.findByText('Student: Alice Johnson')
+    expect(option).toBeInTheDocument()
+  })
+
+  it('selects an option on click', async () => {
+    renderWithProviders(
+      <SearchAutocomplete
+        onSearchChange={mockOnSearchChange}
+        options={options}
+        search=''
+        setSearch={mockSetSearch}
+        textFieldProps={textFieldProps}
+      />
+    )
+
+    const input = screen.getByLabelText('Search')
+    await userEvent.type(input, 'Jane')
+
+    const option = await screen.findByText('Tutor: Jane Smith')
+    await userEvent.click(option)
+
+    expect(mockSetSearch).toHaveBeenCalledWith('Tutor: Jane Smith')
+    expect(mockOnSearchChange).toHaveBeenCalled()
+  })
+
+  it('clears search input on clear icon click', async () => {
+    renderWithProviders(
+      <SearchAutocomplete
+        onSearchChange={mockOnSearchChange}
+        options={options}
+        search='Tutor: John Doe'
+        setSearch={mockSetSearch}
+        textFieldProps={textFieldProps}
+      />
+    )
+
+    const clearButton = screen.getByTestId('ClearIcon').closest('button')
+    await userEvent.click(clearButton)
+
+    expect(mockSetSearch).toHaveBeenCalledWith('')
+    expect(mockOnSearchChange).toHaveBeenCalled()
+  })
+
+  it('triggers search on search button click', async () => {
+    renderWithProviders(
+      <SearchAutocomplete
+        onSearchChange={mockOnSearchChange}
+        options={options}
+        search=''
+        setSearch={mockSetSearch}
+        textFieldProps={textFieldProps}
+      />
+    )
+
+    const input = screen.getByLabelText('Search')
+    await userEvent.type(input, 'Bob')
+
+    const searchButton = screen.getByRole('button', { name: /search/i })
+    await userEvent.click(searchButton)
+
+    expect(mockSetSearch).toHaveBeenCalledWith('Bob')
+    expect(mockOnSearchChange).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This PR adds unit tests covering key behaviors:
   ✓ SearchAutocomplete (6)
     ✓ renders autocomplete with search input
     ✓ updates search input on typing
     ✓ filters options on typing
     ✓ selects an option on click
     ✓ clears search input on clear icon click
     ✓ triggers search on search button click
     
Only the test file SearchAutocomplete.spec.jsx is included. Necessary elements are mocked where needed.