### PR TITLE
test:#53 write tests for question editor component

### DIFF
--- a/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
+++ b/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
@@ -33,51 +33,38 @@ describe('QuestionEditor', () => {
     onEdit = vi.fn()
   })
 
-  it('renders question input field', () => {
-    render(
+  const setup = (props = {}) => {
+    return render(
       <QuestionEditor
         data={mockData}
         handleInputChange={handleInputChange}
         handleNonInputValueChange={handleNonInputValueChange}
+        {...props}
       />
     )
+  }
+
+  it('renders question input field', () => {
+    setup()
     expect(screen.getByLabelText('questionPage.question')).toBeInTheDocument()
   })
 
   it('renders open answer input when type is openAnswer', () => {
-    const data = { ...mockData, type: 'openAnswer', openAnswer: 'Open answer' }
-    render(
-      <QuestionEditor
-        data={data}
-        handleInputChange={handleInputChange}
-        handleNonInputValueChange={handleNonInputValueChange}
-      />
-    )
+    setup({
+      data: { ...mockData, type: 'openAnswer', openAnswer: 'Open answer' }
+    })
     expect(screen.getByLabelText('questionPage.answer')).toBeInTheDocument()
   })
 
   it('changes question type', () => {
-    render(
-      <QuestionEditor
-        data={mockData}
-        handleInputChange={handleInputChange}
-        handleNonInputValueChange={handleNonInputValueChange}
-      />
-    )
+    setup()
     const selectInput = screen.getByTestId('app-select')
     fireEvent.change(selectInput, { target: { value: 'openAnswer' } })
     expect(handleNonInputValueChange).toHaveBeenCalled()
   })
 
   it('changes question and answer input fields', () => {
-    render(
-      <QuestionEditor
-        data={mockData}
-        handleInputChange={handleInputChange}
-        handleNonInputValueChange={handleNonInputValueChange}
-      />
-    )
-
+    setup()
     const questionInput = screen.getByLabelText('questionPage.question')
     fireEvent.change(questionInput, { target: { value: 'New question' } })
     expect(handleInputChange).toHaveBeenCalledWith('text')
@@ -90,16 +77,7 @@ describe('QuestionEditor', () => {
   })
 
   it('clicks on edit title and category', () => {
-    render(
-      <QuestionEditor
-        data={mockData}
-        handleInputChange={handleInputChange}
-        handleNonInputValueChange={handleNonInputValueChange}
-        isQuizQuestion
-        onEdit={onEdit}
-      />
-    )
-
+    setup({ isQuizQuestion: true, onEdit })
     const menuButton = screen.getByTestId('MoreVertIcon').closest('button')
     fireEvent.click(menuButton)
 

--- a/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
+++ b/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
@@ -95,8 +95,8 @@ describe('QuestionEditor', () => {
         data={mockData}
         handleInputChange={handleInputChange}
         handleNonInputValueChange={handleNonInputValueChange}
-        onEdit={onEdit}
         isQuizQuestion
+        onEdit={onEdit}
       />
     )
 

--- a/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
+++ b/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
@@ -33,7 +33,7 @@ describe('QuestionEditor', () => {
     onEdit = vi.fn()
   })
 
-  test('renders question input field', () => {
+  it('renders question input field', () => {
     render(
       <QuestionEditor
         data={mockData}
@@ -44,7 +44,7 @@ describe('QuestionEditor', () => {
     expect(screen.getByLabelText('questionPage.question')).toBeInTheDocument()
   })
 
-  test('renders open answer input when type is openAnswer', () => {
+  it('renders open answer input when type is openAnswer', () => {
     const data = { ...mockData, type: 'openAnswer', openAnswer: 'Open answer' }
     render(
       <QuestionEditor
@@ -56,7 +56,7 @@ describe('QuestionEditor', () => {
     expect(screen.getByLabelText('questionPage.answer')).toBeInTheDocument()
   })
 
-  test('changes question type', () => {
+  it('changes question type', () => {
     render(
       <QuestionEditor
         data={mockData}
@@ -69,7 +69,7 @@ describe('QuestionEditor', () => {
     expect(handleNonInputValueChange).toHaveBeenCalled()
   })
 
-  test('changes question and answer input fields', () => {
+  it('changes question and answer input fields', () => {
     render(
       <QuestionEditor
         data={mockData}
@@ -89,7 +89,7 @@ describe('QuestionEditor', () => {
     expect(handleNonInputValueChange).toHaveBeenCalled()
   })
 
-  test('clicks on edit title and category', () => {
+  it('clicks on edit title and category', () => {
     render(
       <QuestionEditor
         data={mockData}

--- a/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
+++ b/src/tests/unit/components/question-editor/QuestionEditor.spec.jsx
@@ -1,0 +1,113 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import QuestionEditor from '~/components/question-editor/QuestionEditor'
+
+const mockData = {
+  type: 'oneAnswer',
+  text: 'Test question',
+  answers: [{ text: 'Answer 1', isCorrect: false }],
+  openAnswer: ''
+}
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key })
+}))
+
+vi.mock('~/hooks/use-menu', () => ({
+  __esModule: true,
+  default: () => ({
+    openMenu: vi.fn(),
+    closeMenu: vi.fn(),
+    renderMenu: (content) => content
+  })
+}))
+
+describe('QuestionEditor', () => {
+  let handleInputChange
+  let handleNonInputValueChange
+  let onEdit
+
+  beforeEach(() => {
+    handleInputChange = vi.fn()
+    handleNonInputValueChange = vi.fn()
+    onEdit = vi.fn()
+  })
+
+  test('renders question input field', () => {
+    render(
+      <QuestionEditor
+        data={mockData}
+        handleInputChange={handleInputChange}
+        handleNonInputValueChange={handleNonInputValueChange}
+      />
+    )
+    expect(screen.getByLabelText('questionPage.question')).toBeInTheDocument()
+  })
+
+  test('renders open answer input when type is openAnswer', () => {
+    const data = { ...mockData, type: 'openAnswer', openAnswer: 'Open answer' }
+    render(
+      <QuestionEditor
+        data={data}
+        handleInputChange={handleInputChange}
+        handleNonInputValueChange={handleNonInputValueChange}
+      />
+    )
+    expect(screen.getByLabelText('questionPage.answer')).toBeInTheDocument()
+  })
+
+  test('changes question type', () => {
+    render(
+      <QuestionEditor
+        data={mockData}
+        handleInputChange={handleInputChange}
+        handleNonInputValueChange={handleNonInputValueChange}
+      />
+    )
+    const selectInput = screen.getByTestId('app-select')
+    fireEvent.change(selectInput, { target: { value: 'openAnswer' } })
+    expect(handleNonInputValueChange).toHaveBeenCalled()
+  })
+
+  test('changes question and answer input fields', () => {
+    render(
+      <QuestionEditor
+        data={mockData}
+        handleInputChange={handleInputChange}
+        handleNonInputValueChange={handleNonInputValueChange}
+      />
+    )
+
+    const questionInput = screen.getByLabelText('questionPage.question')
+    fireEvent.change(questionInput, { target: { value: 'New question' } })
+    expect(handleInputChange).toHaveBeenCalledWith('text')
+
+    const answerInput = screen.getByPlaceholderText(
+      'questionPage.writeYourAnswer'
+    )
+    fireEvent.change(answerInput, { target: { value: 'New answer' } })
+    expect(handleNonInputValueChange).toHaveBeenCalled()
+  })
+
+  test('clicks on edit title and category', () => {
+    render(
+      <QuestionEditor
+        data={mockData}
+        handleInputChange={handleInputChange}
+        handleNonInputValueChange={handleNonInputValueChange}
+        onEdit={onEdit}
+        isQuizQuestion
+      />
+    )
+
+    const menuButton = screen.getByTestId('MoreVertIcon').closest('button')
+    fireEvent.click(menuButton)
+
+    const editItem = screen.getByText(
+      'myResourcesPage.questions.titleWithCategory'
+    )
+    fireEvent.click(editItem)
+
+    expect(onEdit).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This PR adds unit tests covering key behaviors:
   ✓ QuestionEditor (5)
✓ renders question input field
✓ renders open answer input when type is openAnswer
✓ changes question type
✓ changes question and answer input fields
✓ clicks on edit title and category


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for the QuestionEditor component, covering question input rendering, question type changes, field updates, and contextual menu interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->