### PR TITLE
feat: remove hash from URL after scrolling to top on logo click

### DIFF
--- a/src/containers/layout/navbar/NavBar.tsx
+++ b/src/containers/layout/navbar/NavBar.tsx
@@ -64,6 +64,10 @@ const Navbar = () => {
 
     if (scrollContainer && scrollContainer.scrollTop > 0) {
       scrollContainer.scrollTo({ top: 0, behavior: 'smooth' })
+      // Remove hash from URL after scrolling to top
+      if (window.location.hash) {
+        navigate(window.location.pathname, { replace: true })
+      }
     }
 
     if (pathname !== guestRoutes.home.path) {

--- a/src/tests/unit/containers/navbar/NavBar.spec.jsx
+++ b/src/tests/unit/containers/navbar/NavBar.spec.jsx
@@ -3,6 +3,17 @@ import NavBar from '~/containers/layout/navbar/NavBar'
 import { renderWithProviders } from '~tests/test-utils'
 import { vi } from 'vitest'
 
+// Mock navigate function
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: '/test' })
+  }
+})
+
 vi.mock('~/hooks/use-confirm', () => {
   return {
     default: () => ({ setNeedConfirmation: () => true })
@@ -17,7 +28,9 @@ vi.mock('~/containers/guest-home-page/google-button/GoogleButton', () => ({
 
 describe('Guest NavBar test', () => {
   const preloadedState = { appMain: { loading: false, userRole: '' } }
+
   beforeEach(() => {
+    vi.clearAllMocks()
     renderWithProviders(<NavBar />, { preloadedState })
   })
 
@@ -72,12 +85,49 @@ describe('Guest NavBar test', () => {
     // Cleanup
     querySelectorSpy.mockRestore()
   })
+
+  it('should handle logo click and remove hash from URL when scrolling', () => {
+    // Mock window.location
+    const originalLocation = window.location
+    delete window.location
+    window.location = {
+      ...originalLocation,
+      hash: '#test-section',
+      pathname: '/test-path'
+    }
+
+    // Mock document.querySelector and scrollTo
+    const mockScrollContainer = {
+      scrollTop: 100,
+      scrollTo: vi.fn()
+    }
+    const querySelectorSpy = vi
+      .spyOn(document, 'querySelector')
+      .mockReturnValue(mockScrollContainer)
+
+    const logo = screen.getByAltText('logo')
+    const logoButton = logo.closest('button')
+    fireEvent.click(logoButton)
+
+    expect(mockScrollContainer.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth'
+    })
+
+    // Should call navigate to remove hash
+    expect(mockNavigate).toHaveBeenCalledWith('/test-path', { replace: true })
+
+    // Cleanup
+    querySelectorSpy.mockRestore()
+    window.location = originalLocation
+  })
 })
 
 describe('Student NavBar test', () => {
   const preloadedState = { appMain: { loading: false, userRole: 'student' } }
 
   beforeEach(() => {
+    vi.clearAllMocks()
     renderWithProviders(<NavBar />, { preloadedState })
   })
 


### PR DESCRIPTION
- Added hash removal functionality when scrolling to top
- Uses navigate with replace: true to avoid adding history entry
- Improves UX by cleaning URL after returning to page top