### PR TITLE
fix: #231 adjust font size for How it works title to 32px with responive design

### DIFF
--- a/src/containers/guest-home-page/how-it-works/HowItWorks.styles.ts
+++ b/src/containers/guest-home-page/how-it-works/HowItWorks.styles.ts
@@ -10,5 +10,9 @@ export const styles = {
     mb: '45px',
     flexDirection: { sm: 'row', xs: 'column' }
   },
-  title: { mb: '32px', typography: 'h3' }
+  title: {
+    mb: { xs: 3, md: 4 },
+    typography: 'h4',
+    fontSize: { xs: '32px', md: '48px' }
+  }
 }


### PR DESCRIPTION
Adjusted "How it works" title font size to be responsive:
- 32px on mobile
- 48px on desktop

Fixes #231