### PR TITLE
feat: #81 implement language selection at Language Step at stepper

### DIFF
--- a/src/containers/tutor-home-page/language-step/LanguageStep.jsx
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.jsx
@@ -15,60 +15,23 @@ const ALL_LANGUAGES = [
   { title: 'German', value: 'de' },
   { title: 'French', value: 'fr' },
   { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'French', value: 'fr' },
-  { title: 'Spanish', value: 'es' },
-  { title: 'Ukrainian', value: 'ua' },
-  { title: 'Polish', value: 'pl' },
-  { title: 'German', value: 'de' },
-  { title: 'German', value: 'de' }
+  { title: 'Italian', value: 'it' },
+  { title: 'Chinese', value: 'zh' },
+  { title: 'Japanese', value: 'ja' },
+  { title: 'Korean', value: 'ko' },
+  { title: 'Portuguese', value: 'pt' },
+  { title: 'Dutch', value: 'nl' },
+  { title: 'Swedish', value: 'sv' },
+  { title: 'Norwegian', value: 'no' },
+  { title: 'Finnish', value: 'fi' },
+  { title: 'Czech', value: 'cs' },
+  { title: 'Slovak', value: 'sk' },
+  { title: 'Hungarian', value: 'hu' },
+  { title: 'Turkish', value: 'tr' },
+  { title: 'Greek', value: 'el' },
+  { title: 'Arabic', value: 'ar' },
+  { title: 'Hebrew', value: 'he' },
+  { title: 'Hindi', value: 'hi' }
 ]
 
 const LanguageStep = ({ btnsBox }) => {
@@ -79,9 +42,10 @@ const LanguageStep = ({ btnsBox }) => {
   const [search, setSearch] = useState('')
   const [offset, setOffset] = useState(0)
   const [selectedLanguage, setSelectedLanguage] = useState(null)
+  const [hasMore, setHasMore] = useState(true)
   const { handleStepData } = useStepContext()
 
-  const fetchLanguages = async ({ search = '', offset = 0, limit = 6 }) => {
+  const fetchLanguages = ({ search = '', offset = 0, limit = 6 }) => {
     let filtered = ALL_LANGUAGES
     if (search) {
       filtered = filtered.filter((lang) =>
@@ -92,17 +56,28 @@ const LanguageStep = ({ btnsBox }) => {
   }
 
   useEffect(() => {
+    let cancelled = false
+    setHasMore(true)
+
     const loadLanguages = async () => {
       try {
         const newLangs = await fetchLanguages({ search, offset, limit: 6 })
-        setLanguages((prev) =>
-          offset === 0 ? newLangs : [...prev, ...newLangs]
-        )
+        if (!cancelled) {
+          setLanguages((prev) =>
+            offset === 0 ? newLangs : [...prev, ...newLangs]
+          )
+        }
+        if (newLangs.length < 6) {
+          setHasMore(false)
+        }
       } catch (error) {
         console.error('Failed to load languages:', error)
       }
     }
     loadLanguages()
+    return () => {
+      cancelled = true
+    }
   }, [search, offset])
 
   const handleLanguageChange = (event, newValue) => {
@@ -119,8 +94,9 @@ const LanguageStep = ({ btnsBox }) => {
     const listboxNode = event.currentTarget
 
     if (
+      hasMore &&
       listboxNode.scrollTop + listboxNode.clientHeight >=
-      listboxNode.scrollHeight
+        listboxNode.scrollHeight
     ) {
       setOffset((prev) => prev + 6)
     }
@@ -135,7 +111,11 @@ const LanguageStep = ({ btnsBox }) => {
       )}
       <Box sx={styles.rigthBox}>
         <Box>
-          <Typography sx={styles.description} variant='h6'>
+          <Typography
+            data-testid='lang-step-heading'
+            sx={styles.description}
+            variant='h6'
+          >
             Please select the language in which you would like to study and
             cooperate.
           </Typography>
@@ -148,6 +128,7 @@ const LanguageStep = ({ btnsBox }) => {
 
           <AppAutoComplete
             ListboxProps={{
+              'data-testid': 'lang-listbox',
               onScroll: handleScroll,
               style: { maxHeight: 205 }
             }}
@@ -156,7 +137,7 @@ const LanguageStep = ({ btnsBox }) => {
             onInputChange={handleInputChange}
             options={languages}
             renderOption={(props, option) => (
-              <li {...props} key={option.value}>
+              <li {...props} data-testid='lang-option' key={option.value}>
                 {option.title}
               </li>
             )}

--- a/src/containers/tutor-home-page/language-step/LanguageStep.jsx
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.jsx
@@ -2,15 +2,173 @@ import Box from '@mui/material/Box'
 
 import { styles } from '~/containers/tutor-home-page/language-step/LanguageStep.styles'
 import img from '~/assets/img/tutor-home-page/become-tutor/languages.svg'
+import { Typography, useMediaQuery } from '@mui/material'
+import { useEffect, useState } from 'react'
+import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
+import { useTheme } from '@emotion/react'
+import { useStepContext } from '~/context/step-context'
+
+const ALL_LANGUAGES = [
+  { title: 'English', value: 'en' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'French', value: 'fr' },
+  { title: 'Spanish', value: 'es' },
+  { title: 'Ukrainian', value: 'ua' },
+  { title: 'Polish', value: 'pl' },
+  { title: 'German', value: 'de' },
+  { title: 'German', value: 'de' }
+]
 
 const LanguageStep = ({ btnsBox }) => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'))
+
+  const [languages, setLanguages] = useState([])
+  const [search, setSearch] = useState('')
+  const [offset, setOffset] = useState(0)
+  const [selectedLanguage, setSelectedLanguage] = useState(null)
+  const { handleStepData } = useStepContext()
+
+  const fetchLanguages = async ({ search = '', offset = 0, limit = 6 }) => {
+    let filtered = ALL_LANGUAGES
+    if (search) {
+      filtered = filtered.filter((lang) =>
+        lang.title.toLowerCase().startsWith(search.toLowerCase())
+      )
+    }
+    return filtered.slice(offset, offset + limit)
+  }
+
+  useEffect(() => {
+    const loadLanguages = async () => {
+      try {
+        const newLangs = await fetchLanguages({ search, offset, limit: 6 })
+        setLanguages((prev) =>
+          offset === 0 ? newLangs : [...prev, ...newLangs]
+        )
+      } catch (error) {
+        console.error('Failed to load languages:', error)
+      }
+    }
+    loadLanguages()
+  }, [search, offset])
+
+  const handleLanguageChange = (event, newValue) => {
+    setSelectedLanguage(newValue)
+    handleStepData('Language', newValue)
+  }
+
+  const handleInputChange = (event, value) => {
+    setSearch(value)
+    setOffset(0)
+  }
+
+  const handleScroll = (event) => {
+    const listboxNode = event.currentTarget
+
+    if (
+      listboxNode.scrollTop + listboxNode.clientHeight >=
+      listboxNode.scrollHeight
+    ) {
+      setOffset((prev) => prev + 6)
+    }
+  }
+
   return (
     <Box sx={styles.container}>
-      <Box sx={styles.imgContainer}>
-        <Box component='img' src={img} sx={styles.img} />
-      </Box>
+      {!isMobile && (
+        <Box sx={styles.imgContainer}>
+          <Box component='img' src={img} sx={styles.img} />
+        </Box>
+      )}
       <Box sx={styles.rigthBox}>
-        <Box>Language here</Box>
+        <Box>
+          <Typography sx={styles.description} variant='h6'>
+            Please select the language in which you would like to study and
+            cooperate.
+          </Typography>
+
+          {isMobile && (
+            <Box sx={styles.imgContainer}>
+              <Box component='img' src={img} sx={styles.img} />
+            </Box>
+          )}
+
+          <AppAutoComplete
+            ListboxProps={{
+              onScroll: handleScroll,
+              style: { maxHeight: 205 }
+            }}
+            getOptionLabel={(option) => option.title || ''}
+            onChange={handleLanguageChange}
+            onInputChange={handleInputChange}
+            options={languages}
+            renderOption={(props, option) => (
+              <li {...props} key={option.value}>
+                {option.title}
+              </li>
+            )}
+            sx={styles.inputField}
+            textFieldProps={{
+              label: 'Your native language',
+              placeholder: 'Your native language',
+              variant: 'outlined'
+            }}
+            value={selectedLanguage}
+          />
+        </Box>
         {btnsBox}
       </Box>
     </Box>

--- a/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
@@ -3,6 +3,7 @@ import { fadeAnimation } from '~/styles/app-theme/custom-animations'
 export const styles = {
   container: {
     display: 'flex',
+    flexDirection: { xs: 'column', md: 'row' },
     justifyContent: 'space-between',
     gap: '40px',
     height: { sm: '485px' },
@@ -11,7 +12,8 @@ export const styles = {
   imgContainer: {
     display: 'flex',
     flex: 1,
-    maxWidth: '432px',
+    mt: { xs: 2, md: 0 },
+    maxWidth: { xs: '343px', md: '432px' },
     aspectRatio: { xs: '4/3', sm: 'auto' },
     pb: { xs: '16px', sm: '52px' }
   },
@@ -23,8 +25,20 @@ export const styles = {
     maxWidth: '432px',
     display: 'flex',
     flexDirection: 'column',
+    flexGrow: { md: 0, xs: 1 },
     justifyContent: 'space-between',
     m: { md: 0, xs: '0 auto' },
     pt: 0
+  },
+  description: {
+    mb: 2.5,
+    color: 'text.medium',
+    fontSize: { xs: '14px', sm: '16px' },
+    fontWeight: 400,
+    letterSpacing: '0.15px',
+    lineHeight: 1.3
+  },
+  inputField: {
+    flexGrow: { md: 1, xs: 1 }
   }
 }

--- a/src/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
+++ b/src/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
+import LanguageStep from '~/containers/tutor-home-page/language-step/LanguageStep'
+
+vi.mock('@emotion/react', () => ({
+  useTheme: () => ({
+    breakpoints: { down: () => '(max-width:600px)' }
+  })
+}))
+
+vi.mock('~/context/step-context', () => ({
+  useStepContext: () => ({
+    handleStepData: vi.fn()
+  })
+}))
+
+const setup = () => {
+  render(<LanguageStep btnsBox={<div>Buttons</div>} />)
+  const input = screen.getByRole('combobox')
+  return { input }
+}
+
+const openAutocomplete = async (input) => {
+  await userEvent.click(input)
+  const listbox = await screen.findByTestId('lang-listbox')
+
+  Object.defineProperty(listbox, 'scrollTop', { value: 1000, writable: true })
+  Object.defineProperty(listbox, 'clientHeight', { value: 200, writable: true })
+  Object.defineProperty(listbox, 'scrollHeight', {
+    value: 1000,
+    writable: true
+  })
+
+  return listbox
+}
+
+describe('LanguageStep component', () => {
+  it('should render without crashing', async () => {
+    await waitFor(() => setup())
+    expect(screen.getByTestId('lang-step-heading')).toBeInTheDocument()
+  })
+
+  it('should render first 6 languages by default', async () => {
+    const { input } = setup()
+    await openAutocomplete(input)
+
+    const options = await screen.findAllByTestId('lang-option')
+    expect(options).toHaveLength(6)
+    expect(options[0]).toHaveTextContent('English')
+  })
+
+  it('should filter languages based on search input', async () => {
+    const { input } = setup()
+    await userEvent.type(input, 'sp')
+
+    expect(await screen.findByText('Spanish')).toBeInTheDocument()
+    expect(screen.queryByText('English')).not.toBeInTheDocument()
+  })
+
+  it('should load more languages on scroll when hasMore is true', async () => {
+    const { input } = setup()
+    const listbox = await openAutocomplete(input)
+
+    let options = await screen.findAllByTestId('lang-option')
+    expect(options.length).toBe(6)
+
+    fireEvent.scroll(listbox)
+
+    await waitFor(async () => {
+      options = await screen.findAllByTestId('lang-option')
+      expect(options.length).toBeGreaterThan(6)
+    })
+  })
+
+  it('should not load more when all data loaded (hasMore = false)', async () => {
+    const { input } = setup()
+    await userEvent.type(input, 'f')
+
+    const itemsBefore = await screen.findAllByRole('option')
+    expect(itemsBefore).toHaveLength(2)
+
+    const listbox = await openAutocomplete(input)
+
+    fireEvent.scroll(listbox)
+
+    const itemsAfter = await screen.findAllByRole('option')
+    expect(itemsAfter).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
Implemented language selection at `Language Step` at stepper.

Added:
- description for the language step;
- dropdown with single select, lazy loading (show 6 languages in dropdown) and scroll down (languages are temporarily fetched from a constant);
- adaptive design according to the layout

Related to: https://github.com/Space2Study-UA-4427-4288-01/Issues/issues/81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Language selection step with searchable autocomplete, descriptive heading, and persistence in the step flow.
  * Incremental lazy-loading with 6-item pages and infinite-scroll behavior for the language list.

* Style
  * Responsive layout: decorative image hidden on mobile and shown on larger screens; adjusted spacing and input sizing for better mobile/desktop usability.

* Tests
  * Added unit tests covering rendering, search filtering, lazy-load on scroll, and end-of-data behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->