### PR TITLE
Feature/71 sp 1 confirmation pop up window

### DIFF
--- a/src/components/close-confirmation-dialog/CloseConfirmationDialog.styles.ts
+++ b/src/components/close-confirmation-dialog/CloseConfirmationDialog.styles.ts
@@ -36,6 +36,19 @@ const SPACING = {
   BUTTON_GAP: '16px'
 } as const
 
+const baseButtonStyles = {
+  height: { xs: '36px', sm: '40px', md: '40px' },
+  padding: { xs: '4px 16px', sm: '5px 20px', md: '5px 20px' },
+  borderRadius: '4px',
+  minWidth: { xs: '80px', sm: '60px', md: '60px' },
+  fontSize: { xs: '13px', sm: '14px', md: '14px' },
+  fontWeight: 500,
+  fontFamily: 'Rubik, sans-serif',
+  lineHeight: { xs: '18px', sm: '20px', md: '20px' },
+  letterSpacing: '0.5px',
+  textTransform: 'none'
+} as const
+
 export const styles = {
   dialogPaper: {
     borderRadius: SIZES.BORDER_RADIUS,
@@ -115,18 +128,9 @@ export const styles = {
     flexDirection: { xs: 'column', sm: 'row' }
   },
   confirmButton: {
+    ...baseButtonStyles,
     backgroundColor: COLORS.BUTTON_BG,
     color: COLORS.WHITE,
-    height: { xs: '36px', sm: '40px', md: '40px' },
-    padding: { xs: '4px 16px', sm: '5px 20px', md: '5px 20px' },
-    borderRadius: '4px',
-    minWidth: { xs: '80px', sm: '60px', md: '60px' },
-    fontSize: { xs: '13px', sm: '14px', md: '14px' },
-    fontWeight: 500,
-    fontFamily: 'Rubik, sans-serif',
-    lineHeight: { xs: '18px', sm: '20px', md: '20px' },
-    letterSpacing: '0.5px',
-    textTransform: 'none',
     boxShadow: `0px 3px 16px ${COLORS.BUTTON_SHADOW}, 0px 9px 12px ${COLORS.BUTTON_SHADOW}`,
     '&:hover': {
       backgroundColor: COLORS.BUTTON_HOVER,
@@ -138,18 +142,9 @@ export const styles = {
     }
   },
   cancelButton: {
+    ...baseButtonStyles,
     backgroundColor: '#E0E0E0',
     color: '#263238',
-    height: { xs: '36px', sm: '40px', md: '40px' },
-    padding: { xs: '4px 16px', sm: '5px 20px', md: '5px 20px' },
-    borderRadius: '4px',
-    minWidth: { xs: '80px', sm: '60px', md: '60px' },
-    fontSize: { xs: '13px', sm: '14px', md: '14px' },
-    fontWeight: 500,
-    fontFamily: 'Rubik, sans-serif',
-    lineHeight: { xs: '18px', sm: '20px', md: '20px' },
-    letterSpacing: '0.5px',
-    textTransform: 'none',
     border: 'none',
     '&:hover': {
       backgroundColor: '#BDBDBD',

--- a/src/components/close-confirmation-dialog/CloseConfirmationDialog.styles.ts
+++ b/src/components/close-confirmation-dialog/CloseConfirmationDialog.styles.ts
@@ -1,0 +1,159 @@
+const COLORS = {
+  WHITE: '#FFFFFF',
+  BLACK: '#000000',
+  TITLE: '#29313D',
+  MESSAGE: '#666666',
+  BUTTON_BG: '#263238',
+  BUTTON_HOVER: '#1a2529',
+  BUTTON_ACTIVE: '#0f1416',
+  BACKDROP: 'rgba(38, 50, 56, 0.75)',
+  HOVER_OVERLAY: 'rgba(0, 0, 0, 0.04)',
+  SHADOW: 'rgba(0, 0, 0, 0.1)',
+  BUTTON_SHADOW: 'rgba(144, 164, 174, 0.12)',
+  BUTTON_SHADOW_HOVER: 'rgba(144, 164, 174, 0.16)',
+  BORDER_COLOR: '#E0E0E0',
+  BORDER_HOVER: '#BDBDBD'
+} as const
+
+const SIZES = {
+  BORDER_RADIUS: '4px',
+  BUTTON_HEIGHT: '56px',
+  CLOSE_BUTTON_SIZE: '48px',
+  TITLE_FONT_SIZE: '20px',
+  MESSAGE_FONT_SIZE: '14px',
+  MESSAGE_LINE_HEIGHT: '20px',
+  BUTTON_FONT_SIZE: '16px'
+} as const
+
+const SPACING = {
+  SMALL: '12px',
+  MEDIUM: '16px',
+  LARGE: '24px',
+  XLARGE: '32px',
+  TITLE_MARGIN_BOTTOM: '18px',
+  MESSAGE_MARGIN_BOTTOM: '30px',
+  BUTTON_MARGIN_BOTTOM: '50px',
+  BUTTON_GAP: '16px'
+} as const
+
+export const styles = {
+  dialogPaper: {
+    borderRadius: SIZES.BORDER_RADIUS,
+    width: { xs: '90vw', sm: '400px', md: '501px' },
+    minHeight: { xs: '130px', sm: '140px', md: '140px' },
+    maxHeight: '90vh',
+    backgroundColor: COLORS.WHITE,
+    boxShadow: `0px 8px 32px ${COLORS.SHADOW}`,
+    margin: { xs: '16px', sm: '24px' }
+  },
+  backdrop: {
+    backgroundColor: COLORS.BACKDROP,
+    backdropFilter: 'blur(4px)'
+  },
+  dialogContent: {
+    padding: { xs: '16px', sm: '19px', md: '19px' },
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    height: '100%',
+    boxSizing: 'border-box'
+  },
+  closeButton: {
+    position: 'absolute',
+    top: '15px',
+    right: SPACING.MEDIUM,
+    width: SIZES.CLOSE_BUTTON_SIZE,
+    height: SIZES.CLOSE_BUTTON_SIZE,
+    minWidth: SIZES.CLOSE_BUTTON_SIZE,
+    borderRadius: '100px',
+    color: COLORS.BLACK,
+    backgroundColor: 'transparent',
+    padding: SPACING.SMALL,
+    '&:hover': {
+      backgroundColor: COLORS.HOVER_OVERLAY
+    },
+    '& .MuiSvgIcon-root': {
+      fontSize: SIZES.TITLE_FONT_SIZE
+    }
+  },
+  title: {
+    marginTop: '5px',
+    marginBottom: { xs: '12px', sm: '16px', md: '20px' },
+    color: '#424242',
+    fontWeight: 600,
+    fontSize: { xs: '18px', sm: '20px', md: '20px' },
+    lineHeight: '120%',
+    fontFamily: 'Rubik, sans-serif',
+    letterSpacing: '0.2px',
+    textAlign: 'left',
+    maxWidth: 'none',
+    whiteSpace: 'normal',
+    overflow: 'visible',
+    textOverflow: 'unset',
+    marginLeft: { xs: '5px', sm: '7px', md: '7px' }
+  },
+  message: {
+    marginBottom: { xs: '16px', sm: '18px', md: '20px' },
+    marginLeft: { xs: '5px', sm: '7px', md: '7px' },
+    color: COLORS.MESSAGE,
+    fontSize: { xs: '13px', sm: '14px', md: '14px' },
+    lineHeight: { xs: '18px', sm: '20px', md: '20px' },
+    letterSpacing: '0.1px',
+    fontFamily: 'Rubik, sans-serif',
+    fontWeight: 400,
+    textAlign: 'left',
+    maxWidth: 'none'
+  },
+  buttonsContainer: {
+    display: 'flex',
+    justifyContent: { xs: 'center', sm: 'flex-end' },
+    gap: { xs: '8px', sm: '7px', md: '7px' },
+    marginBottom: '0px',
+    marginRight: { xs: '0px', sm: '5px', md: '5px' },
+    marginTop: 'auto',
+    flexDirection: { xs: 'column', sm: 'row' }
+  },
+  confirmButton: {
+    backgroundColor: COLORS.BUTTON_BG,
+    color: COLORS.WHITE,
+    height: { xs: '36px', sm: '40px', md: '40px' },
+    padding: { xs: '4px 16px', sm: '5px 20px', md: '5px 20px' },
+    borderRadius: '4px',
+    minWidth: { xs: '80px', sm: '60px', md: '60px' },
+    fontSize: { xs: '13px', sm: '14px', md: '14px' },
+    fontWeight: 500,
+    fontFamily: 'Rubik, sans-serif',
+    lineHeight: { xs: '18px', sm: '20px', md: '20px' },
+    letterSpacing: '0.5px',
+    textTransform: 'none',
+    boxShadow: `0px 3px 16px ${COLORS.BUTTON_SHADOW}, 0px 9px 12px ${COLORS.BUTTON_SHADOW}`,
+    '&:hover': {
+      backgroundColor: COLORS.BUTTON_HOVER,
+      boxShadow: `0px 3px 16px ${COLORS.BUTTON_SHADOW_HOVER}, 0px 9px 12px ${COLORS.BUTTON_SHADOW_HOVER}`
+    },
+    '&:active': {
+      backgroundColor: COLORS.BUTTON_ACTIVE,
+      transform: 'translateY(1px)'
+    }
+  },
+  cancelButton: {
+    backgroundColor: '#E0E0E0',
+    color: '#263238',
+    height: { xs: '36px', sm: '40px', md: '40px' },
+    padding: { xs: '4px 16px', sm: '5px 20px', md: '5px 20px' },
+    borderRadius: '4px',
+    minWidth: { xs: '80px', sm: '60px', md: '60px' },
+    fontSize: { xs: '13px', sm: '14px', md: '14px' },
+    fontWeight: 500,
+    fontFamily: 'Rubik, sans-serif',
+    lineHeight: { xs: '18px', sm: '20px', md: '20px' },
+    letterSpacing: '0.5px',
+    textTransform: 'none',
+    border: 'none',
+    '&:hover': {
+      backgroundColor: '#BDBDBD',
+      border: 'none'
+    }
+  }
+} as const

--- a/src/components/close-confirmation-dialog/CloseConfirmationDialog.tsx
+++ b/src/components/close-confirmation-dialog/CloseConfirmationDialog.tsx
@@ -1,0 +1,101 @@
+import { FC, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import CloseIcon from '@mui/icons-material/Close'
+import Dialog from '@mui/material/Dialog'
+import DialogContent from '@mui/material/DialogContent'
+import IconButton from '@mui/material/IconButton'
+import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+import Box from '@mui/material/Box'
+
+import { styles } from '~/components/close-confirmation-dialog/CloseConfirmationDialog.styles'
+
+interface CloseConfirmationDialogProps {
+  open: boolean
+  onDismiss: () => void
+}
+
+const CloseConfirmationDialog: FC<CloseConfirmationDialogProps> = ({
+  open,
+  onDismiss
+}) => {
+  const navigate = useNavigate()
+
+  const handleConfirmClose = useCallback(() => {
+    onDismiss()
+    navigate('/')
+  }, [navigate, onDismiss])
+
+  const handleBackdropClick = useCallback(
+    (
+      _event:
+        | React.MouseEvent<HTMLDivElement>
+        | React.KeyboardEvent<HTMLDivElement>,
+      reason: 'backdropClick' | 'escapeKeyDown'
+    ) => {
+      if (reason === 'backdropClick') {
+        return
+      }
+      onDismiss()
+    },
+    [onDismiss]
+  )
+
+  return (
+    <Dialog
+      PaperProps={{ sx: styles.dialogPaper }}
+      data-testid='closeConfirmationDialog'
+      fullWidth={false}
+      maxWidth={false}
+      onClose={handleBackdropClick}
+      open={open}
+      slotProps={{
+        backdrop: {
+          sx: styles.backdrop
+        }
+      }}
+    >
+      <DialogContent sx={styles.dialogContent}>
+        <IconButton
+          aria-label='Close confirmation dialog'
+          data-testid='close-button'
+          onClick={onDismiss}
+          sx={styles.closeButton}
+        >
+          <CloseIcon />
+        </IconButton>
+
+        <Typography sx={styles.title} variant='h6'>
+          Please Confirm
+        </Typography>
+
+        <Typography sx={styles.message}>
+          Are you certain you want to close? Any unsaved changes will be lost
+        </Typography>
+
+        <Box sx={styles.buttonsContainer}>
+          <Button
+            aria-label='Confirm close'
+            data-testid='confirm-button'
+            onClick={handleConfirmClose}
+            sx={styles.confirmButton}
+            variant='contained'
+          >
+            Yes
+          </Button>
+          <Button
+            aria-label='Cancel close'
+            data-testid='cancel-button'
+            onClick={onDismiss}
+            sx={styles.cancelButton}
+            variant='outlined'
+          >
+            No
+          </Button>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default CloseConfirmationDialog

--- a/src/tests/unit/components/close-confirmation-dialog/CloseConfirmationDialog.spec.jsx
+++ b/src/tests/unit/components/close-confirmation-dialog/CloseConfirmationDialog.spec.jsx
@@ -36,21 +36,22 @@ const renderWithRouter = (component) => {
   return render(<BrowserRouter>{component}</BrowserRouter>)
 }
 
+const getElements = () => ({
+  title: screen.getByText(TEST_CONSTANTS.TITLE),
+  message: screen.getByText(TEST_CONSTANTS.MESSAGE),
+  yesButton: screen.getByText(TEST_CONSTANTS.YES_BUTTON),
+  noButton: screen.getByText(TEST_CONSTANTS.NO_BUTTON),
+  closeButton: screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID),
+  confirmButton: screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID),
+  cancelButton: screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID),
+  dialog: screen.getByRole('dialog')
+})
+
 const expectAllElementsPresent = () => {
-  expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
-  expect(screen.getByText(TEST_CONSTANTS.MESSAGE)).toBeInTheDocument()
-  expect(screen.getByText(TEST_CONSTANTS.YES_BUTTON)).toBeInTheDocument()
-  expect(screen.getByText(TEST_CONSTANTS.NO_BUTTON)).toBeInTheDocument()
-  expect(
-    screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
-  ).toBeInTheDocument()
-  expect(
-    screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
-  ).toBeInTheDocument()
-  expect(
-    screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
-  ).toBeInTheDocument()
-  expect(screen.getByRole('dialog')).toBeInTheDocument()
+  const elements = getElements()
+  Object.values(elements).forEach((element) =>
+    expect(element).toBeInTheDocument()
+  )
 }
 
 const expectDialogClosed = () => {
@@ -63,19 +64,22 @@ const expectDialogOpen = () => {
   expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
 }
 
+const clickButton = (buttonType) => {
+  const elements = getElements()
+  fireEvent.click(elements[buttonType])
+}
+
+const expectButtonClick = (buttonType, expectedCalls = 1) => {
+  clickButton(buttonType)
+  expect(mockOnDismiss).toHaveBeenCalledTimes(expectedCalls)
+}
+
 describe('CloseConfirmationDialog', () => {
   const renderDialog = (props = {}) => {
     return renderWithRouter(
       <CloseConfirmationDialog {...defaultProps} {...props} />
     )
   }
-
-  const getElements = () => ({
-    closeButton: screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID),
-    confirmButton: screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID),
-    cancelButton: screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID),
-    dialog: screen.getByRole('dialog')
-  })
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -93,40 +97,27 @@ describe('CloseConfirmationDialog', () => {
 
   it('should call onDismiss when close button is clicked', () => {
     renderDialog()
-    const { closeButton } = getElements()
-
-    fireEvent.click(closeButton)
-
-    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
+    expectButtonClick('closeButton')
   })
 
   it('should call onDismiss when No button is clicked', () => {
     renderDialog()
-    const { cancelButton } = getElements()
-
-    fireEvent.click(cancelButton)
-
-    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
+    expectButtonClick('cancelButton')
   })
 
   it('should call onDismiss and navigate to home when Yes button is clicked', () => {
     renderDialog()
-    const { confirmButton } = getElements()
-
-    fireEvent.click(confirmButton)
-
+    clickButton('confirmButton')
     expect(mockOnDismiss).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 
   it('should not close popup when clicking on backdrop', () => {
     renderDialog()
-
     const backdrop = document.querySelector('.MuiBackdrop-root')
     if (backdrop) {
       fireEvent.click(backdrop)
     }
-
     expect(mockOnDismiss).not.toHaveBeenCalled()
     expectDialogOpen()
   })
@@ -134,16 +125,13 @@ describe('CloseConfirmationDialog', () => {
   it('should call onDismiss when Escape key is pressed', () => {
     renderDialog()
     const { dialog } = getElements()
-
     fireEvent.keyDown(dialog, { key: 'Escape', code: 'Escape' })
-
     expect(mockOnDismiss).toHaveBeenCalledTimes(1)
   })
 
   it('should have proper accessibility attributes', () => {
     renderDialog()
     const { closeButton, confirmButton, cancelButton } = getElements()
-
     expect(closeButton).toHaveAttribute(
       'aria-label',
       'Close confirmation dialog'
@@ -152,40 +140,12 @@ describe('CloseConfirmationDialog', () => {
     expect(cancelButton).toHaveAttribute('aria-label', 'Cancel close')
   })
 
-  it('should have proper Dialog configuration', () => {
-    renderDialog()
-    const { dialog } = getElements()
-
-    expect(dialog).toBeInTheDocument()
-    expect(dialog).toHaveClass('MuiDialog-paper')
-    expect(dialog.closest('[role="dialog"]')).toBeInTheDocument()
-  })
-
-  it('should display correct text content', () => {
-    renderDialog()
-
-    expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
-    expect(screen.getByText(TEST_CONSTANTS.MESSAGE)).toBeInTheDocument()
-    expect(screen.getByText(TEST_CONSTANTS.YES_BUTTON)).toBeInTheDocument()
-    expect(screen.getByText(TEST_CONSTANTS.NO_BUTTON)).toBeInTheDocument()
-  })
-
-  it('should have proper button styling classes', () => {
-    renderDialog()
-    const { confirmButton, cancelButton } = getElements()
-
-    expect(confirmButton).toHaveClass('MuiButton-contained')
-    expect(cancelButton).toHaveClass('MuiButton-outlined')
-  })
-
   it('should handle multiple rapid clicks on Yes button correctly', () => {
     renderDialog()
     const { confirmButton } = getElements()
-
     fireEvent.click(confirmButton)
     fireEvent.click(confirmButton)
     fireEvent.click(confirmButton)
-
     expect(mockOnDismiss).toHaveBeenCalledTimes(3)
     expect(mockNavigate).toHaveBeenCalledTimes(3)
     expect(mockNavigate).toHaveBeenCalledWith('/')
@@ -193,7 +153,6 @@ describe('CloseConfirmationDialog', () => {
 
   it('should render with proper test IDs', () => {
     renderDialog()
-
     expect(
       screen.getByTestId(TEST_CONSTANTS.DIALOG_TEST_ID)
     ).toBeInTheDocument()

--- a/src/tests/unit/components/close-confirmation-dialog/CloseConfirmationDialog.spec.jsx
+++ b/src/tests/unit/components/close-confirmation-dialog/CloseConfirmationDialog.spec.jsx
@@ -36,6 +36,33 @@ const renderWithRouter = (component) => {
   return render(<BrowserRouter>{component}</BrowserRouter>)
 }
 
+const expectAllElementsPresent = () => {
+  expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
+  expect(screen.getByText(TEST_CONSTANTS.MESSAGE)).toBeInTheDocument()
+  expect(screen.getByText(TEST_CONSTANTS.YES_BUTTON)).toBeInTheDocument()
+  expect(screen.getByText(TEST_CONSTANTS.NO_BUTTON)).toBeInTheDocument()
+  expect(
+    screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
+  ).toBeInTheDocument()
+  expect(
+    screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
+  ).toBeInTheDocument()
+  expect(
+    screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
+  ).toBeInTheDocument()
+  expect(screen.getByRole('dialog')).toBeInTheDocument()
+}
+
+const expectDialogClosed = () => {
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  expect(screen.queryByText(TEST_CONSTANTS.TITLE)).not.toBeInTheDocument()
+}
+
+const expectDialogOpen = () => {
+  expect(screen.getByRole('dialog')).toBeInTheDocument()
+  expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
+}
+
 describe('CloseConfirmationDialog', () => {
   const renderDialog = (props = {}) => {
     return renderWithRouter(
@@ -56,31 +83,12 @@ describe('CloseConfirmationDialog', () => {
 
   it('should render when open is true', () => {
     renderDialog()
-
-    expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
-    expect(screen.getByText(TEST_CONSTANTS.MESSAGE)).toBeInTheDocument()
-    expect(screen.getByText(TEST_CONSTANTS.YES_BUTTON)).toBeInTheDocument()
-    expect(screen.getByText(TEST_CONSTANTS.NO_BUTTON)).toBeInTheDocument()
-    expect(
-      screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
-    ).toBeInTheDocument()
-    expect(
-      screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
-    ).toBeInTheDocument()
-    expect(
-      screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
-    ).toBeInTheDocument()
+    expectAllElementsPresent()
   })
 
   it('should not render when open is false', () => {
     renderDialog({ open: false })
-
-    expect(screen.queryByText(TEST_CONSTANTS.TITLE)).not.toBeInTheDocument()
-    expect(screen.queryByText(TEST_CONSTANTS.MESSAGE)).not.toBeInTheDocument()
-    expect(
-      screen.queryByText(TEST_CONSTANTS.YES_BUTTON)
-    ).not.toBeInTheDocument()
-    expect(screen.queryByText(TEST_CONSTANTS.NO_BUTTON)).not.toBeInTheDocument()
+    expectDialogClosed()
   })
 
   it('should call onDismiss when close button is clicked', () => {
@@ -113,7 +121,6 @@ describe('CloseConfirmationDialog', () => {
 
   it('should not close popup when clicking on backdrop', () => {
     renderDialog()
-    const { dialog } = getElements()
 
     const backdrop = document.querySelector('.MuiBackdrop-root')
     if (backdrop) {
@@ -121,7 +128,7 @@ describe('CloseConfirmationDialog', () => {
     }
 
     expect(mockOnDismiss).not.toHaveBeenCalled()
-    expect(dialog).toBeInTheDocument()
+    expectDialogOpen()
   })
 
   it('should call onDismiss when Escape key is pressed', () => {

--- a/src/tests/unit/components/close-confirmation-dialog/CloseConfirmationDialog.spec.jsx
+++ b/src/tests/unit/components/close-confirmation-dialog/CloseConfirmationDialog.spec.jsx
@@ -37,12 +37,25 @@ const renderWithRouter = (component) => {
 }
 
 describe('CloseConfirmationDialog', () => {
+  const renderDialog = (props = {}) => {
+    return renderWithRouter(
+      <CloseConfirmationDialog {...defaultProps} {...props} />
+    )
+  }
+
+  const getElements = () => ({
+    closeButton: screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID),
+    confirmButton: screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID),
+    cancelButton: screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID),
+    dialog: screen.getByRole('dialog')
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   it('should render when open is true', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
 
     expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
     expect(screen.getByText(TEST_CONSTANTS.MESSAGE)).toBeInTheDocument()
@@ -60,7 +73,7 @@ describe('CloseConfirmationDialog', () => {
   })
 
   it('should not render when open is false', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} open={false} />)
+    renderDialog({ open: false })
 
     expect(screen.queryByText(TEST_CONSTANTS.TITLE)).not.toBeInTheDocument()
     expect(screen.queryByText(TEST_CONSTANTS.MESSAGE)).not.toBeInTheDocument()
@@ -71,59 +84,58 @@ describe('CloseConfirmationDialog', () => {
   })
 
   it('should call onDismiss when close button is clicked', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
+    const { closeButton } = getElements()
 
-    const closeButton = screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
     fireEvent.click(closeButton)
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(1)
   })
 
   it('should call onDismiss when No button is clicked', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
+    const { cancelButton } = getElements()
 
-    const noButton = screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
-    fireEvent.click(noButton)
+    fireEvent.click(cancelButton)
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(1)
   })
 
   it('should call onDismiss and navigate to home when Yes button is clicked', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
+    const { confirmButton } = getElements()
 
-    const yesButton = screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
-    fireEvent.click(yesButton)
+    fireEvent.click(confirmButton)
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 
   it('should not close popup when clicking on backdrop', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
+    const { dialog } = getElements()
+
+    const backdrop = document.querySelector('.MuiBackdrop-root')
+    if (backdrop) {
+      fireEvent.click(backdrop)
+    }
 
     expect(mockOnDismiss).not.toHaveBeenCalled()
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(dialog).toBeInTheDocument()
   })
 
   it('should call onDismiss when Escape key is pressed', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
+    const { dialog } = getElements()
 
-    const dialog = screen.getByRole('dialog')
     fireEvent.keyDown(dialog, { key: 'Escape', code: 'Escape' })
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(1)
   })
 
   it('should have proper accessibility attributes', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
-
-    const closeButton = screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
-    const confirmButton = screen.getByTestId(
-      TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID
-    )
-    const cancelButton = screen.getByTestId(
-      TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID
-    )
+    renderDialog()
+    const { closeButton, confirmButton, cancelButton } = getElements()
 
     expect(closeButton).toHaveAttribute(
       'aria-label',
@@ -134,57 +146,46 @@ describe('CloseConfirmationDialog', () => {
   })
 
   it('should have proper Dialog configuration', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
+    const { dialog } = getElements()
 
-    const dialog = screen.getByRole('dialog')
     expect(dialog).toBeInTheDocument()
     expect(dialog).toHaveClass('MuiDialog-paper')
     expect(dialog.closest('[role="dialog"]')).toBeInTheDocument()
   })
 
   it('should display correct text content', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
 
-    const title = screen.getByText(TEST_CONSTANTS.TITLE)
-    const message = screen.getByText(TEST_CONSTANTS.MESSAGE)
-    const yesButton = screen.getByText(TEST_CONSTANTS.YES_BUTTON)
-    const noButton = screen.getByText(TEST_CONSTANTS.NO_BUTTON)
-
-    expect(title).toBeInTheDocument()
-    expect(message).toBeInTheDocument()
-    expect(yesButton).toBeInTheDocument()
-    expect(noButton).toBeInTheDocument()
+    expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
+    expect(screen.getByText(TEST_CONSTANTS.MESSAGE)).toBeInTheDocument()
+    expect(screen.getByText(TEST_CONSTANTS.YES_BUTTON)).toBeInTheDocument()
+    expect(screen.getByText(TEST_CONSTANTS.NO_BUTTON)).toBeInTheDocument()
   })
 
   it('should have proper button styling classes', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
-
-    const confirmButton = screen.getByTestId(
-      TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID
-    )
-    const cancelButton = screen.getByTestId(
-      TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID
-    )
+    renderDialog()
+    const { confirmButton, cancelButton } = getElements()
 
     expect(confirmButton).toHaveClass('MuiButton-contained')
     expect(cancelButton).toHaveClass('MuiButton-outlined')
   })
 
-  it('should handle multiple rapid clicks correctly', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+  it('should handle multiple rapid clicks on Yes button correctly', () => {
+    renderDialog()
+    const { confirmButton } = getElements()
 
-    const yesButton = screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
-    const noButton = screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
-
-    fireEvent.click(yesButton)
-    fireEvent.click(noButton)
-    fireEvent.click(yesButton)
+    fireEvent.click(confirmButton)
+    fireEvent.click(confirmButton)
+    fireEvent.click(confirmButton)
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(3)
+    expect(mockNavigate).toHaveBeenCalledTimes(3)
+    expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 
   it('should render with proper test IDs', () => {
-    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+    renderDialog()
 
     expect(
       screen.getByTestId(TEST_CONSTANTS.DIALOG_TEST_ID)

--- a/src/tests/unit/components/close-confirmation-dialog/CloseConfirmationDialog.spec.jsx
+++ b/src/tests/unit/components/close-confirmation-dialog/CloseConfirmationDialog.spec.jsx
@@ -1,0 +1,202 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import { BrowserRouter } from 'react-router-dom'
+import CloseConfirmationDialog from '~/components/close-confirmation-dialog/CloseConfirmationDialog'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  }
+})
+
+const TEST_CONSTANTS = {
+  TITLE: 'Please Confirm',
+  MESSAGE:
+    'Are you certain you want to close? Any unsaved changes will be lost',
+  YES_BUTTON: 'Yes',
+  NO_BUTTON: 'No',
+  CLOSE_BUTTON_TEST_ID: 'close-button',
+  CONFIRM_BUTTON_TEST_ID: 'confirm-button',
+  CANCEL_BUTTON_TEST_ID: 'cancel-button',
+  DIALOG_TEST_ID: 'closeConfirmationDialog'
+}
+
+const mockOnDismiss = vi.fn()
+
+const defaultProps = {
+  open: true,
+  onDismiss: mockOnDismiss
+}
+
+const renderWithRouter = (component) => {
+  return render(<BrowserRouter>{component}</BrowserRouter>)
+}
+
+describe('CloseConfirmationDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render when open is true', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    expect(screen.getByText(TEST_CONSTANTS.TITLE)).toBeInTheDocument()
+    expect(screen.getByText(TEST_CONSTANTS.MESSAGE)).toBeInTheDocument()
+    expect(screen.getByText(TEST_CONSTANTS.YES_BUTTON)).toBeInTheDocument()
+    expect(screen.getByText(TEST_CONSTANTS.NO_BUTTON)).toBeInTheDocument()
+    expect(
+      screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
+    ).toBeInTheDocument()
+  })
+
+  it('should not render when open is false', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} open={false} />)
+
+    expect(screen.queryByText(TEST_CONSTANTS.TITLE)).not.toBeInTheDocument()
+    expect(screen.queryByText(TEST_CONSTANTS.MESSAGE)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(TEST_CONSTANTS.YES_BUTTON)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText(TEST_CONSTANTS.NO_BUTTON)).not.toBeInTheDocument()
+  })
+
+  it('should call onDismiss when close button is clicked', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const closeButton = screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
+    fireEvent.click(closeButton)
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onDismiss when No button is clicked', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const noButton = screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
+    fireEvent.click(noButton)
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call onDismiss and navigate to home when Yes button is clicked', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const yesButton = screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
+    fireEvent.click(yesButton)
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith('/')
+  })
+
+  it('should not close popup when clicking on backdrop', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    expect(mockOnDismiss).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('should call onDismiss when Escape key is pressed', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.keyDown(dialog, { key: 'Escape', code: 'Escape' })
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('should have proper accessibility attributes', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const closeButton = screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
+    const confirmButton = screen.getByTestId(
+      TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID
+    )
+    const cancelButton = screen.getByTestId(
+      TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID
+    )
+
+    expect(closeButton).toHaveAttribute(
+      'aria-label',
+      'Close confirmation dialog'
+    )
+    expect(confirmButton).toHaveAttribute('aria-label', 'Confirm close')
+    expect(cancelButton).toHaveAttribute('aria-label', 'Cancel close')
+  })
+
+  it('should have proper Dialog configuration', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveClass('MuiDialog-paper')
+    expect(dialog.closest('[role="dialog"]')).toBeInTheDocument()
+  })
+
+  it('should display correct text content', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const title = screen.getByText(TEST_CONSTANTS.TITLE)
+    const message = screen.getByText(TEST_CONSTANTS.MESSAGE)
+    const yesButton = screen.getByText(TEST_CONSTANTS.YES_BUTTON)
+    const noButton = screen.getByText(TEST_CONSTANTS.NO_BUTTON)
+
+    expect(title).toBeInTheDocument()
+    expect(message).toBeInTheDocument()
+    expect(yesButton).toBeInTheDocument()
+    expect(noButton).toBeInTheDocument()
+  })
+
+  it('should have proper button styling classes', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const confirmButton = screen.getByTestId(
+      TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID
+    )
+    const cancelButton = screen.getByTestId(
+      TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID
+    )
+
+    expect(confirmButton).toHaveClass('MuiButton-contained')
+    expect(cancelButton).toHaveClass('MuiButton-outlined')
+  })
+
+  it('should handle multiple rapid clicks correctly', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    const yesButton = screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
+    const noButton = screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
+
+    fireEvent.click(yesButton)
+    fireEvent.click(noButton)
+    fireEvent.click(yesButton)
+
+    expect(mockOnDismiss).toHaveBeenCalledTimes(3)
+  })
+
+  it('should render with proper test IDs', () => {
+    renderWithRouter(<CloseConfirmationDialog {...defaultProps} />)
+
+    expect(
+      screen.getByTestId(TEST_CONSTANTS.DIALOG_TEST_ID)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(TEST_CONSTANTS.CLOSE_BUTTON_TEST_ID)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(TEST_CONSTANTS.CONFIRM_BUTTON_TEST_ID)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(TEST_CONSTANTS.CANCEL_BUTTON_TEST_ID)
+    ).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Added `CloseConfirmationDialog` component for confirming close actions with unsaved changes warning.

**New Files:**
- `CloseConfirmationDialog.tsx` - Confirmation dialog component
- `CloseConfirmationDialog.styles.ts` - Component styles  
- `CloseConfirmationDialog.spec.jsx` - Unit tests 

## Features

- Confirmation dialog with Yes/No buttons
- "Yes" closes dialog and navigates to home page
- "No" only closes dialog
- Backdrop click does not close (only ESC or buttons)
- Responsive design (mobile/tablet/desktop)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a close confirmation dialog with title, message, close icon, Yes/No actions, Escape-key dismissal, backdrop handling, and navigation on confirmation; accessible and responsive.
* **Style**
  * Centralized dialog styling with colors, spacing, responsive typography, hover/active states, shadows, borders, and layout rules.
* **Tests**
  * Comprehensive unit tests covering rendering, interactions, accessibility, dismissal behavior, repeated clicks, and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->