### PR TITLE
feat: #88 categories implement create request block

### DIFF
--- a/src/pages/categories/Categories.styles.ts
+++ b/src/pages/categories/Categories.styles.ts
@@ -1,0 +1,54 @@
+export const styles = {
+  pageWrapper: {
+    px: { xs: '20px', sm: '40px', md: '65px' }
+  },
+  titleWithDescription: {
+    wrapper: {
+      mt: { xs: '20px', sm: '25px', md: '30px' },
+      mb: 0,
+      textAlign: 'center'
+    },
+    title: {
+      fontFamily: 'Rubik',
+      fontWeight: 500,
+      fontSize: { xs: '24px', sm: '28px', md: '32px' },
+      lineHeight: '100%',
+      letterSpacing: '0.05px',
+      color: '#263238',
+      textAlign: 'center',
+      marginBottom: { xs: '8px', sm: '10px' }
+    },
+    description: {
+      typography: { sm: 'body1', xs: 'body2' },
+      color: 'primary.500'
+    }
+  },
+  showAllOffers: {
+    display: 'flex',
+    justifyContent: 'end',
+    alignItems: 'center',
+    columnGap: { xs: '8px', sm: '10px' },
+    color: 'primary.500',
+    textDecoration: 'none',
+    m: { xs: '0 5px 10px 0', sm: '0 8px 12px 0', md: '0 10px 5px 0' }
+  },
+  searchToolbar: {
+    borderRadius: '70px',
+    mb: { xs: '20px', sm: '25px', md: '30px' }
+  },
+  // TODO: Temporary styles for search results demo
+  // Will be replaced/modified when CategoriesList component is integrated
+  searchResults: {
+    mt: { xs: '20px', sm: '25px', md: '30px' }
+  },
+  categoriesGrid: {
+    display: 'grid',
+    gridTemplateColumns: {
+      xs: '1fr',
+      sm: 'repeat(2, 1fr)',
+      md: 'repeat(3, 1fr)',
+      lg: 'repeat(4, 1fr)'
+    },
+    gap: { xs: '16px', sm: '20px', md: '24px' }
+  }
+}

--- a/src/pages/categories/Categories.styles.ts
+++ b/src/pages/categories/Categories.styles.ts
@@ -35,20 +35,5 @@ export const styles = {
   searchToolbar: {
     borderRadius: '70px',
     mb: { xs: '20px', sm: '25px', md: '30px' }
-  },
-  // TODO: Temporary styles for search results demo
-  // Will be replaced/modified when CategoriesList component is integrated
-  searchResults: {
-    mt: { xs: '20px', sm: '25px', md: '30px' }
-  },
-  categoriesGrid: {
-    display: 'grid',
-    gridTemplateColumns: {
-      xs: '1fr',
-      sm: 'repeat(2, 1fr)',
-      md: 'repeat(3, 1fr)',
-      lg: 'repeat(4, 1fr)'
-    },
-    gap: { xs: '16px', sm: '20px', md: '24px' }
   }
 }

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useRef } from 'react'
+import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
@@ -10,64 +10,39 @@ import TitleWithDescription from '~/components/title-with-description/TitleWithD
 import SearchAutocomplete from '~/components/search-autocomplete/SearchAutocomplete'
 import DirectionLink from '~/components/direction-link/DirectionLink'
 import AppToolbar from '~/components/app-toolbar/AppToolbar'
-import CardWithLink from '~/components/card-with-link/CardWithLink'
-import NotFoundResults from '~/components/not-found-results/NotFoundResults'
-import Loader from '~/components/loader/Loader'
+import CategoriesList from '~/components/categories-list/CategoriesList'
 import CreateSubjectModal from '~/containers/find-offer/create-new-subject/CreateNewSubject'
 
 import { authRoutes } from '~/router/constants/authRoutes'
 import { categoryService } from '~/services/category-service'
-import { useDebounce } from '~/hooks/use-debounce'
-import useAxios from '~/hooks/use-axios'
-import { defaultResponses } from '~/constants'
+import useLoadMore from '~/hooks/use-load-more'
+import useBreakpoints from '~/hooks/use-breakpoints'
+import { itemsLoadLimit } from '~/constants'
 import { useModalContext } from '~/context/modal-context'
-import { ItemsWithCount, CategoryInterface } from '~/types'
+import { CategoryInterface } from '~/types'
+import { getScreenBasedLimit } from '~/utils/helper-functions'
 import { styles } from './Categories.styles'
 
 const Categories = () => {
   const [match, setMatch] = useState<string>('')
-  const searchRef = useRef<string>('')
   const { t } = useTranslation()
   const { openModal } = useModalContext()
+  const breakpoints = useBreakpoints()
 
-  // Search functionality - provides filtered categories data
-  // Available for integration: response.items, loading, match
-  // For use in "Implement list of categories block" task
-  const getCategories = useCallback(
-    () =>
-      categoryService.getCategories({
-        name: searchRef.current
-      }),
-    []
-  )
+  const cardsLimit = getScreenBasedLimit(breakpoints, itemsLoadLimit)
+  const params = useMemo(() => ({ name: match }), [match])
 
-  const { response, loading, fetchData } = useAxios<
-    ItemsWithCount<CategoryInterface>
-  >({
-    service: getCategories,
-    defaultResponse: defaultResponses.itemsWithCount
+  const {
+    data: categories,
+    loading,
+    resetData,
+    loadMore,
+    isExpandable
+  } = useLoadMore<CategoryInterface, { name: string }>({
+    service: categoryService.getCategories,
+    limit: cardsLimit,
+    params
   })
-
-  const debounceOnChange = useDebounce((text: string) => {
-    searchRef.current = text
-    void fetchData()
-  })
-
-  const handleSearchChange = useCallback(
-    (value: string | ((prevState: string) => string)) => {
-      const newValue = typeof value === 'function' ? value(match) : value
-      setMatch(newValue)
-      debounceOnChange(newValue)
-    },
-    [debounceOnChange, match]
-  )
-
-  const handleSearch = useCallback(() => {
-    if (match.trim() && !loading) {
-      searchRef.current = match.trim()
-      void fetchData()
-    }
-  }, [match, fetchData, loading])
 
   const handleOpenModal = () => openModal({ component: <CreateSubjectModal /> })
 
@@ -91,48 +66,24 @@ const Categories = () => {
 
       <AppToolbar sx={styles.searchToolbar}>
         <SearchAutocomplete
-          onSearchChange={handleSearch}
-          options={response?.items?.map((category) => category.name) || []}
+          onSearchChange={resetData}
+          options={categories?.map((category) => category.name) || []}
           search={match}
-          setSearch={handleSearchChange}
+          setSearch={setMatch}
           textFieldProps={{
             label: t('categoriesPage.searchLabel')
           }}
         />
       </AppToolbar>
 
-      {/* TODO: Цей блок буде замінений на CategoriesList компонент (task: Implement list of categories block) */}
-      {/* ВАЖЛИВО: NotFoundResults має залишитися для показу коли нічого не знайдено при пошуку */}
-      {/* Поточна реалізація - тимчасова, для демонстрації функціоналу пошуку */}
-      {match && (
-        <Box sx={styles.searchResults}>
-          {loading ? (
-            <Loader />
-          ) : response?.items && response.items.length > 0 ? (
-            <Box sx={styles.categoriesGrid}>
-              {response.items.map((category: CategoryInterface) => (
-                <CardWithLink
-                  description={`${category.totalOffers?.student || 0} offers available`}
-                  img={category.appearance?.icon || ''}
-                  key={category._id}
-                  link={`${authRoutes.categories.path}/${category._id}`}
-                  title={category.name}
-                />
-              ))}
-            </Box>
-          ) : (
-            <NotFoundResults
-              buttonText={t('errorMessages.buttonRequest', {
-                name: 'categories'
-              })}
-              description={t('errorMessages.tryAgainText', {
-                name: 'categories'
-              })}
-              onClick={handleOpenModal}
-            />
-          )}
-        </Box>
-      )}
+      <CategoriesList
+        categories={categories}
+        isExpandable={isExpandable}
+        loading={loading}
+        onLoadMore={loadMore}
+        onRequestNewCategory={handleOpenModal}
+        searchQuery={match}
+      />
     </PageWrapper>
   )
 }

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -1,7 +1,12 @@
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
+import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
 
 const Categories = () => {
-  return <PageWrapper>Categories</PageWrapper>
+  return (
+    <PageWrapper>
+      <OfferRequestBlock />
+    </PageWrapper>
+  )
 }
 
 export default Categories

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -63,11 +63,11 @@ const Categories = () => {
   )
 
   const handleSearch = useCallback(() => {
-    if (match.trim()) {
+    if (match.trim() && !loading) {
       searchRef.current = match.trim()
       void fetchData()
     }
-  }, [match, fetchData])
+  }, [match, fetchData, loading])
 
   const handleOpenModal = () => openModal({ component: <CreateSubjectModal /> })
 

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -1,10 +1,138 @@
+import { useCallback, useState, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import Box from '@mui/material/Box'
+import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
 import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
+import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
+import SearchAutocomplete from '~/components/search-autocomplete/SearchAutocomplete'
+import DirectionLink from '~/components/direction-link/DirectionLink'
+import AppToolbar from '~/components/app-toolbar/AppToolbar'
+import CardWithLink from '~/components/card-with-link/CardWithLink'
+import NotFoundResults from '~/components/not-found-results/NotFoundResults'
+import Loader from '~/components/loader/Loader'
+import CreateSubjectModal from '~/containers/find-offer/create-new-subject/CreateNewSubject'
+
+import { authRoutes } from '~/router/constants/authRoutes'
+import { categoryService } from '~/services/category-service'
+import { useDebounce } from '~/hooks/use-debounce'
+import useAxios from '~/hooks/use-axios'
+import { defaultResponses } from '~/constants'
+import { useModalContext } from '~/context/modal-context'
+import { ItemsWithCount, CategoryInterface } from '~/types'
+import { styles } from './Categories.styles'
 
 const Categories = () => {
+  const [match, setMatch] = useState<string>('')
+  const searchRef = useRef<string>('')
+  const { t } = useTranslation()
+  const { openModal } = useModalContext()
+
+  // Search functionality - provides filtered categories data
+  // Available for integration: response.items, loading, match
+  // For use in "Implement list of categories block" task
+  const getCategories = useCallback(
+    () =>
+      categoryService.getCategories({
+        name: searchRef.current
+      }),
+    [searchRef]
+  )
+
+  const { response, loading, fetchData } = useAxios<
+    ItemsWithCount<CategoryInterface>
+  >({
+    service: getCategories,
+    defaultResponse: defaultResponses.itemsWithCount
+  })
+
+  const debounceOnChange = useDebounce((text: string) => {
+    searchRef.current = text
+    void fetchData()
+  })
+
+  const handleSearchChange = useCallback(
+    (value: string | ((prevState: string) => string)) => {
+      const text = typeof value === 'function' ? value(match) : value
+      setMatch(text)
+      debounceOnChange(text)
+    },
+    [debounceOnChange, match]
+  )
+
+  const handleSearch = useCallback(() => {
+    if (match.trim()) {
+      searchRef.current = match.trim()
+      void fetchData()
+    }
+  }, [match, fetchData])
+
+  const handleOpenModal = () => openModal({ component: <CreateSubjectModal /> })
+
   return (
-    <PageWrapper>
+    <PageWrapper sx={styles.pageWrapper}>
       <OfferRequestBlock />
+
+      <TitleWithDescription
+        description={t('categoriesPage.description')}
+        style={styles.titleWithDescription}
+        title={t('categoriesPage.title')}
+      />
+
+      <Box sx={styles.showAllOffers}>
+        <DirectionLink
+          after={<ArrowForwardIcon fontSize='small' />}
+          linkTo={authRoutes.findOffers.path}
+          title={t('categoriesPage.showAllOffers')}
+        />
+      </Box>
+
+      <AppToolbar sx={styles.searchToolbar}>
+        <SearchAutocomplete
+          onSearchChange={handleSearch}
+          options={response?.items?.map((category) => category.name) || []}
+          search={match}
+          setSearch={handleSearchChange}
+          textFieldProps={{
+            label: t('categoriesPage.searchLabel')
+          }}
+        />
+      </AppToolbar>
+
+      {/* TODO: Цей блок буде замінений на CategoriesList компонент (task: Implement list of categories block) */}
+      {/* ВАЖЛИВО: NotFoundResults має залишитися для показу коли нічого не знайдено при пошуку */}
+      {/* Поточна реалізація - тимчасова, для демонстрації функціоналу пошуку */}
+      {match && (
+        <Box sx={styles.searchResults}>
+          {loading ? (
+            <Loader />
+          ) : response?.items && response.items.length > 0 ? (
+            <Box sx={styles.categoriesGrid}>
+              {response.items.map((category: CategoryInterface) => (
+                <CardWithLink
+                  description={`${category.totalOffers?.student || 0} offers available`}
+                  img={category.appearance?.icon || ''}
+                  key={category._id}
+                  link={`/categories/${category._id}`}
+                  title={category.name}
+                />
+              ))}
+            </Box>
+          ) : (
+            <NotFoundResults
+              buttonText={t('errorMessages.buttonRequest', {
+                name: 'categories'
+              })}
+              description={t('errorMessages.tryAgainText', {
+                name: 'categories'
+              })}
+              onClick={handleOpenModal}
+            />
+          )}
+        </Box>
+      )}
     </PageWrapper>
   )
 }

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -38,7 +38,7 @@ const Categories = () => {
       categoryService.getCategories({
         name: searchRef.current
       }),
-    [searchRef]
+    []
   )
 
   const { response, loading, fetchData } = useAxios<
@@ -55,9 +55,9 @@ const Categories = () => {
 
   const handleSearchChange = useCallback(
     (value: string | ((prevState: string) => string)) => {
-      const text = typeof value === 'function' ? value(match) : value
-      setMatch(text)
-      debounceOnChange(text)
+      const newValue = typeof value === 'function' ? value(match) : value
+      setMatch(newValue)
+      debounceOnChange(newValue)
     },
     [debounceOnChange, match]
   )
@@ -115,7 +115,7 @@ const Categories = () => {
                   description={`${category.totalOffers?.student || 0} offers available`}
                   img={category.appearance?.icon || ''}
                   key={category._id}
-                  link={`/categories/${category._id}`}
+                  link={`${authRoutes.categories.path}/${category._id}`}
                   title={category.name}
                 />
               ))}

--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -1,7 +1,12 @@
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
+import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
 
 const FindOffers = () => {
-  return <PageWrapper>Find offers</PageWrapper>
+  return (
+    <PageWrapper>
+      <OfferRequestBlock />
+    </PageWrapper>
+  )
 }
 
 export default FindOffers

--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -1,12 +1,7 @@
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
-import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
 
 const FindOffers = () => {
-  return (
-    <PageWrapper>
-      <OfferRequestBlock />
-    </PageWrapper>
-  )
+  return <PageWrapper>Find offers</PageWrapper>
 }
 
 export default FindOffers

--- a/src/tests/unit/pages/categories/Categories.spec.jsx
+++ b/src/tests/unit/pages/categories/Categories.spec.jsx
@@ -1,7 +1,11 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { renderWithProviders } from '~tests/test-utils'
 import Categories from '~/pages/categories/Categories'
 import { vi } from 'vitest'
+import { categoryService } from '~/services/category-service'
+
+vi.mock('~/services/category-service')
 
 const mockCategories = [
   {
@@ -22,24 +26,9 @@ const mockCategories = [
   }
 ]
 
-vi.mock('~/services/category-service', () => ({
-  categoryService: {
-    getCategories: vi.fn(() =>
-      Promise.resolve({
-        data: {
-          count: mockCategories.length,
-          items: mockCategories
-        }
-      })
-    ),
-    getCategoriesNames: vi.fn()
-  }
-}))
-
-const mockOpenModal = vi.fn()
-
 vi.mock('~/context/modal-context', async () => {
   const actual = await vi.importActual('~/context/modal-context')
+  const mockOpenModal = vi.fn()
   return {
     ...actual,
     useModalContext: () => ({
@@ -52,101 +41,172 @@ vi.mock('~/context/modal-context', async () => {
 const getSearchInput = () =>
   screen.getByRole('combobox', { name: /categoriesPage.searchLabel/i })
 
+const getSearchButton = () =>
+  screen.getByRole('button', { name: /common.search/i })
+
 describe('Categories component tests', () => {
+  let user
+
   beforeEach(() => {
-    renderWithProviders(<Categories />)
+    user = userEvent.setup()
+    vi.clearAllMocks()
+    categoryService.getCategories.mockResolvedValue({
+      data: {
+        count: mockCategories.length,
+        items: mockCategories
+      }
+    })
   })
 
   describe('Rendering', () => {
     it('should render all main elements', () => {
-      const title = screen.getByText('categoriesPage.title')
-      const description = screen.getByText('categoriesPage.description')
-      const showAllLink = screen.getByText('categoriesPage.showAllOffers')
-      const searchLabel = screen.getByText('categoriesPage.searchLabel')
-      const offerRequestButton = screen.getByText(
-        'findOffers.offerRequestBlock.button'
-      )
+      renderWithProviders(<Categories />)
+      expect(screen.getByText('categoriesPage.title')).toBeInTheDocument()
+      expect(screen.getByText('categoriesPage.description')).toBeInTheDocument()
+      expect(
+        screen.getByText('categoriesPage.showAllOffers')
+      ).toBeInTheDocument()
+      expect(screen.getByText('categoriesPage.searchLabel')).toBeInTheDocument()
+      expect(
+        screen.getByText('findOffers.offerRequestBlock.button')
+      ).toBeInTheDocument()
+    })
 
-      expect(title).toBeInTheDocument()
-      expect(description).toBeInTheDocument()
-      expect(showAllLink).toBeInTheDocument()
-      expect(searchLabel).toBeInTheDocument()
-      expect(offerRequestButton).toBeInTheDocument()
+    it('should render categories list on initial load', async () => {
+      renderWithProviders(<Categories />)
+      await waitFor(() => {
+        expect(screen.getByText('Mathematics')).toBeInTheDocument()
+        expect(screen.getByText('Marketing')).toBeInTheDocument()
+        const mathLink = screen.getByText('Mathematics').closest('a')
+        expect(mathLink).toHaveAttribute(
+          'href',
+          '/categories/subjects?categoryId=1'
+        )
+        expect(screen.getAllByText(/offers/).length).toBeGreaterThan(0)
+      })
+    })
+
+    it('should render "View more" button when there are more categories', async () => {
+      categoryService.getCategories.mockResolvedValueOnce({
+        data: {
+          count: 20,
+          items: mockCategories
+        }
+      })
+      renderWithProviders(<Categories />)
+      await waitFor(() => {
+        expect(screen.getByText('categoriesPage.viewMore')).toBeInTheDocument()
+      })
     })
   })
 
   describe('Search functionality', () => {
-    it('should update search input and display results in dropdown and cards', async () => {
+    it('should update search input and display autocomplete options', async () => {
+      renderWithProviders(<Categories />)
       const searchInput = getSearchInput()
 
-      fireEvent.change(searchInput, { target: { value: 'Math' } })
-
-      await waitFor(
-        () => {
-          expect(searchInput.value).toBe('Math')
-
-          const mathOption = screen.getByRole('option', { name: 'Mathematics' })
-          expect(mathOption).toBeInTheDocument()
-
-          const mathCard = screen.getByText('Mathematics')
-          expect(mathCard).toBeInTheDocument()
-        },
-        { timeout: 1000 }
-      )
-    })
-
-    it('should perform search when search button is clicked', async () => {
-      const searchInput = getSearchInput()
-
-      fireEvent.change(searchInput, { target: { value: 'Marketing' } })
-
-      const searchButton = screen.getByText('common.search')
-      fireEvent.click(searchButton)
-
-      await waitFor(
-        () => {
-          const marketingOption = screen.queryByRole('option', {
-            name: 'Marketing'
-          })
-          expect(marketingOption).toBeInTheDocument()
-        },
-        { timeout: 1000 }
-      )
-    })
-
-    it('should display multiple categories when partial match', async () => {
-      const searchInput = getSearchInput()
-
-      fireEvent.change(searchInput, { target: { value: 'Ma' } })
-
-      await waitFor(
-        () => {
-          const mathCategory = screen.getByText('Mathematics')
-          const marketingCategory = screen.getByText('Marketing')
-
-          expect(mathCategory).toBeInTheDocument()
-          expect(marketingCategory).toBeInTheDocument()
-        },
-        { timeout: 1000 }
-      )
-    })
-
-    it('should handle empty and whitespace search gracefully', async () => {
-      const searchInput = getSearchInput()
-      const searchButton = screen.getByText('common.search')
-
-      fireEvent.change(searchInput, { target: { value: '   ' } })
-      fireEvent.click(searchButton)
+      await user.type(searchInput, 'Ma')
 
       await waitFor(() => {
-        expect(searchInput.value).toBe('   ')
+        expect(searchInput).toHaveValue('Ma')
+        expect(
+          screen.getByRole('option', { name: 'Mathematics' })
+        ).toBeInTheDocument()
+        expect(
+          screen.getByRole('option', { name: 'Marketing' })
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('should trigger search when search button is clicked', async () => {
+      renderWithProviders(<Categories />)
+      const searchInput = getSearchInput()
+      const searchButton = getSearchButton()
+
+      await user.type(searchInput, 'Marketing')
+      await user.click(searchButton)
+
+      expect(searchInput).toHaveValue('Marketing')
+    })
+
+    it('should handle empty search input', async () => {
+      renderWithProviders(<Categories />)
+      const searchInput = getSearchInput()
+
+      await user.click(getSearchButton())
+
+      expect(searchInput).toHaveValue('')
+    })
+
+    it('should clear search input when clear icon is clicked', async () => {
+      renderWithProviders(<Categories />)
+      const searchInput = getSearchInput()
+
+      await user.type(searchInput, 'Test')
+      await user.click(screen.getByTestId('ClearIcon').closest('button'))
+
+      expect(searchInput).toHaveValue('')
+    })
+  })
+
+  describe('Empty State and Modal functionality', () => {
+    it('should show empty state and open modal when request button is clicked', async () => {
+      categoryService.getCategories.mockResolvedValueOnce({
+        data: {
+          count: 0,
+          items: []
+        }
       })
 
-      fireEvent.change(searchInput, { target: { value: '' } })
-      fireEvent.click(searchButton)
+      renderWithProviders(<Categories />)
 
       await waitFor(() => {
-        expect(searchInput.value).toBe('')
+        expect(
+          screen.getByText('categoriesPage.description', { exact: false })
+        ).toBeInTheDocument()
+      })
+
+      const requestButton = screen.getByText('errorMessages.buttonRequest')
+      await user.click(requestButton)
+    })
+  })
+
+  describe('Load More functionality', () => {
+    it('should load more categories when button is clicked', async () => {
+      categoryService.getCategories
+        .mockResolvedValueOnce({
+          data: {
+            count: 20,
+            items: mockCategories
+          }
+        })
+        .mockResolvedValueOnce({
+          data: {
+            count: 20,
+            items: [
+              {
+                _id: '3',
+                name: 'Physics',
+                appearance: { icon: 'physics-icon.svg', color: '#4CAF50' },
+                totalOffers: { student: 20, tutor: 15 },
+                createdAt: '2024-01-02',
+                updatedAt: '2024-01-02'
+              }
+            ]
+          }
+        })
+
+      renderWithProviders(<Categories />)
+
+      await waitFor(() => {
+        expect(screen.getByText('categoriesPage.viewMore')).toBeInTheDocument()
+      })
+
+      const loadMoreButton = screen.getByText('categoriesPage.viewMore')
+      await user.click(loadMoreButton)
+
+      await waitFor(() => {
+        expect(screen.getByText('Physics')).toBeInTheDocument()
       })
     })
   })

--- a/src/tests/unit/pages/categories/Categories.spec.jsx
+++ b/src/tests/unit/pages/categories/Categories.spec.jsx
@@ -1,0 +1,153 @@
+import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '~tests/test-utils'
+import Categories from '~/pages/categories/Categories'
+import { vi } from 'vitest'
+
+const mockCategories = [
+  {
+    _id: '1',
+    name: 'Mathematics',
+    appearance: { icon: 'math-icon.svg', color: '#FFD700' },
+    totalOffers: { student: 15, tutor: 10 },
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01'
+  },
+  {
+    _id: '2',
+    name: 'Marketing',
+    appearance: { icon: 'marketing-icon.svg', color: '#FF6B6B' },
+    totalOffers: { student: 8, tutor: 5 },
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01'
+  }
+]
+
+vi.mock('~/services/category-service', () => ({
+  categoryService: {
+    getCategories: vi.fn(() =>
+      Promise.resolve({
+        data: {
+          count: mockCategories.length,
+          items: mockCategories
+        }
+      })
+    ),
+    getCategoriesNames: vi.fn()
+  }
+}))
+
+const mockOpenModal = vi.fn()
+
+vi.mock('~/context/modal-context', async () => {
+  const actual = await vi.importActual('~/context/modal-context')
+  return {
+    ...actual,
+    useModalContext: () => ({
+      openModal: mockOpenModal,
+      closeModal: vi.fn()
+    })
+  }
+})
+
+const getSearchInput = () =>
+  screen.getByRole('combobox', { name: /categoriesPage.searchLabel/i })
+
+describe('Categories component tests', () => {
+  beforeEach(() => {
+    renderWithProviders(<Categories />)
+  })
+
+  describe('Rendering', () => {
+    it('should render all main elements', () => {
+      const title = screen.getByText('categoriesPage.title')
+      const description = screen.getByText('categoriesPage.description')
+      const showAllLink = screen.getByText('categoriesPage.showAllOffers')
+      const searchLabel = screen.getByText('categoriesPage.searchLabel')
+      const offerRequestButton = screen.getByText(
+        'findOffers.offerRequestBlock.button'
+      )
+
+      expect(title).toBeInTheDocument()
+      expect(description).toBeInTheDocument()
+      expect(showAllLink).toBeInTheDocument()
+      expect(searchLabel).toBeInTheDocument()
+      expect(offerRequestButton).toBeInTheDocument()
+    })
+  })
+
+  describe('Search functionality', () => {
+    it('should update search input and display results in dropdown and cards', async () => {
+      const searchInput = getSearchInput()
+
+      fireEvent.change(searchInput, { target: { value: 'Math' } })
+
+      await waitFor(
+        () => {
+          expect(searchInput.value).toBe('Math')
+
+          const mathOption = screen.getByRole('option', { name: 'Mathematics' })
+          expect(mathOption).toBeInTheDocument()
+
+          const mathCard = screen.getByText('Mathematics')
+          expect(mathCard).toBeInTheDocument()
+        },
+        { timeout: 1000 }
+      )
+    })
+
+    it('should perform search when search button is clicked', async () => {
+      const searchInput = getSearchInput()
+
+      fireEvent.change(searchInput, { target: { value: 'Marketing' } })
+
+      const searchButton = screen.getByText('common.search')
+      fireEvent.click(searchButton)
+
+      await waitFor(
+        () => {
+          const marketingOption = screen.queryByRole('option', {
+            name: 'Marketing'
+          })
+          expect(marketingOption).toBeInTheDocument()
+        },
+        { timeout: 1000 }
+      )
+    })
+
+    it('should display multiple categories when partial match', async () => {
+      const searchInput = getSearchInput()
+
+      fireEvent.change(searchInput, { target: { value: 'Ma' } })
+
+      await waitFor(
+        () => {
+          const mathCategory = screen.getByText('Mathematics')
+          const marketingCategory = screen.getByText('Marketing')
+
+          expect(mathCategory).toBeInTheDocument()
+          expect(marketingCategory).toBeInTheDocument()
+        },
+        { timeout: 1000 }
+      )
+    })
+
+    it('should handle empty and whitespace search gracefully', async () => {
+      const searchInput = getSearchInput()
+      const searchButton = screen.getByText('common.search')
+
+      fireEvent.change(searchInput, { target: { value: '   ' } })
+      fireEvent.click(searchButton)
+
+      await waitFor(() => {
+        expect(searchInput.value).toBe('   ')
+      })
+
+      fireEvent.change(searchInput, { target: { value: '' } })
+      fireEvent.click(searchButton)
+
+      await waitFor(() => {
+        expect(searchInput.value).toBe('')
+      })
+    })
+  })
+})


### PR DESCRIPTION
feat(categories): implement search functionality with tests

- Add search input with debounced autocomplete
- Display filtered category cards in responsive grid
- Show NotFoundResults when no matches found
- Add modal for requesting new categories
- Create test suite
- Style components according to Figma design
- Add integration comments for CategoriesList task

(SP: 1) [Categories] Implement "Create request" block #88
(SP: 1) [Categories] Add title with description and search input#89
(SP: 1) Implement "Sorry, no results found" block#90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Categories page: stateful search with autocomplete, responsive result grid, integrated create-category modal, navigation to offers, and improved UI composition.

* **Style**
  * Added responsive layout tokens and styling for the Categories page (wrapper, title/description, toolbar, results layout).

* **Tests**
  * Added unit tests covering rendering, search/autocomplete interactions, create-modal trigger, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->