### PR TITLE
feat: #82 implement stepper Category selection at Subjects Step at stepper

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -18,7 +18,8 @@
     "subjectLabel": "Subject",
     "btnText": "Add one more subject",
     "emptyFields": "All fields must be filled",
-    "sameSubject": "You have the same subject"
+    "sameSubject": "You have the same subject",
+    "imageAlt": "Study category illustration"
   },
   "photo": {
     "imageAlt": "Your photo",

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -1,13 +1,42 @@
 import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import Autocomplete from '@mui/material/Autocomplete'
+import TextField from '@mui/material/TextField'
 
 import { styles } from '~/containers/tutor-home-page/subjects-step/SubjectsStep.styles'
+import img from '~/assets/img/tutor-home-page/become-tutor/study-category.svg'
+import en from '~/constants/translations/en/become-tutor.json'
+import { categoriesMock } from './constants.js'
 
 const SubjectsStep = ({ btnsBox }) => {
+  const t = en.categories
+
   return (
     <Box sx={styles.container}>
-      <Box sx={styles.rigthBox}>
-        Subjects step
-        {btnsBox}
+      <Box sx={styles.imgContainer}>
+        <Box component='img' src={img} sx={styles.img} alt='Study category' />
+      </Box>
+
+      <Box sx={styles.rightBox}>
+        <Typography variant='body1' sx={styles.description}>
+          {t.title}
+        </Typography>
+
+        <Autocomplete
+          disablePortal
+          options={categoriesMock}
+          getOptionLabel={(option) => option.name}
+          sx={styles.dropdown}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label={t.mainSubjectsLabel}
+              placeholder={t.mainSubjectsLabel}
+            />
+          )}
+        />
+
+        <Box sx={{ mt: 'auto', width: '100%' }}>{btnsBox}</Box>
       </Box>
     </Box>
   )

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -15,9 +15,9 @@ const SubjectsStep = ({ btnsBox }) => {
     <Box sx={styles.container}>
       <Box sx={styles.imgContainer}>
         <Box
+          alt={t('becomeTutor.categories.imageAlt')}
           component='img'
           src={img}
-          alt={t('becomeTutor.categories.imageAlt')}
           sx={styles.img}
         />
       </Box>

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -14,19 +14,18 @@ const SubjectsStep = ({ btnsBox }) => {
   return (
     <Box sx={styles.container}>
       <Box sx={styles.imgContainer}>
-        <Box component='img' src={img} sx={styles.img} alt='Study category' />
+        <Box alt='Study category' component='img' src={img} sx={styles.img} />
       </Box>
 
       <Box sx={styles.rightBox}>
-        <Typography variant='body1' sx={styles.description}>
+        <Typography sx={styles.description} variant='body1'>
           {t.title}
         </Typography>
 
         <Autocomplete
           disablePortal
-          options={categoriesMock}
           getOptionLabel={(option) => option.name}
-          sx={styles.dropdown}
+          options={categoriesMock}
           renderInput={(params) => (
             <TextField
               {...params}
@@ -34,9 +33,12 @@ const SubjectsStep = ({ btnsBox }) => {
               placeholder={t.mainSubjectsLabel}
             />
           )}
+          sx={styles.dropdown}
         />
 
-        <Box sx={{ mt: 'auto', width: '100%' }}>{btnsBox}</Box>
+        <Box mt='auto' sx={{ width: '100%' }}>
+          {btnsBox}
+        </Box>
       </Box>
     </Box>
   )

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Autocomplete from '@mui/material/Autocomplete'
@@ -5,21 +6,25 @@ import TextField from '@mui/material/TextField'
 
 import { styles } from '~/containers/tutor-home-page/subjects-step/SubjectsStep.styles'
 import img from '~/assets/img/tutor-home-page/become-tutor/study-category.svg'
-import en from '~/constants/translations/en/become-tutor.json'
 import { categoriesMock } from './constants.js'
 
 const SubjectsStep = ({ btnsBox }) => {
-  const t = en.categories
+  const { t } = useTranslation()
 
   return (
     <Box sx={styles.container}>
       <Box sx={styles.imgContainer}>
-        <Box alt='Study category' component='img' src={img} sx={styles.img} />
+        <Box
+          component='img'
+          src={img}
+          alt={t('becomeTutor.categories.imageAlt')}
+          sx={styles.img}
+        />
       </Box>
 
       <Box sx={styles.rightBox}>
         <Typography sx={styles.description} variant='body1'>
-          {t.title}
+          {t('becomeTutor.categories.title')}
         </Typography>
 
         <Autocomplete
@@ -29,8 +34,8 @@ const SubjectsStep = ({ btnsBox }) => {
           renderInput={(params) => (
             <TextField
               {...params}
-              label={t.mainSubjectsLabel}
-              placeholder={t.mainSubjectsLabel}
+              label={t('becomeTutor.categories.mainSubjectsLabel')}
+              placeholder={t('becomeTutor.categories.mainSubjectsLabel')}
             />
           )}
           sx={styles.dropdown}

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -3,11 +3,9 @@ import { fadeAnimation } from '~/styles/app-theme/custom-animations'
 export const styles = {
   container: {
     display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'stretch',
+    flexDirection: { xs: 'column', md: 'row' },
     gap: { xs: '30px', md: '40px' },
     paddingBottom: { xs: '30px', sm: '0px' },
-    flexDirection: { xs: 'column', md: 'row' },
     alignItems: { xs: 'center', md: 'stretch' },
     justifyContent: { xs: 'center', md: 'space-between' },
     ...fadeAnimation

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -5,16 +5,12 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'stretch',
-    gap: '40px',
+    gap: { xs: '30px', md: '40px' },
     paddingBottom: { xs: '30px', sm: '0px' },
-    ...fadeAnimation,
-
-    '@media (max-width: 1024px)': {
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'center',
-      gap: '30px'
-    }
+    flexDirection: { xs: 'column', md: 'row' },
+    alignItems: { xs: 'center', md: 'stretch' },
+    justifyContent: { xs: 'center', md: 'space-between' },
+    ...fadeAnimation
   },
 
   imgContainer: {
@@ -26,14 +22,8 @@ export const styles = {
 
   img: {
     width: '100%',
-    maxWidth: '350px',
-    height: 'auto',
-    '@media (max-width: 1024px)': {
-      maxWidth: '280px'
-    },
-    '@media (max-width: 600px)': {
-      maxWidth: '220px'
-    }
+    maxWidth: { xs: '220px', sm: '280px', md: '350px' },
+    height: 'auto'
   },
 
   rightBox: {
@@ -43,21 +33,14 @@ export const styles = {
     gap: '20px',
     width: '100%',
     maxWidth: '420px',
-
-    '@media (max-width: 1024px)': {
-      alignItems: 'center',
-      textAlign: 'center',
-      maxWidth: '90%'
-    }
+    alignItems: { xs: 'center', md: 'flex-start' },
+    textAlign: { xs: 'center', md: 'left' }
   },
 
   description: {
     fontSize: '14px',
     lineHeight: '20px',
-    textAlign: 'left',
-    '@media (max-width: 1024px)': {
-      textAlign: 'center'
-    }
+    textAlign: { xs: 'center', md: 'left' }
   },
 
   dropdown: {

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -4,9 +4,63 @@ export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'stretch',
     gap: '40px',
-    height: { sm: '485px' },
     paddingBottom: { xs: '30px', sm: '0px' },
-    ...fadeAnimation
+    ...fadeAnimation,
+
+    '@media (max-width: 1024px)': {
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '30px'
+    }
+  },
+
+  imgContainer: {
+    flex: 1,
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+
+  img: {
+    width: '100%',
+    maxWidth: '350px',
+    height: 'auto',
+    '@media (max-width: 1024px)': {
+      maxWidth: '280px'
+    },
+    '@media (max-width: 600px)': {
+      maxWidth: '220px'
+    }
+  },
+
+  rightBox: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '20px',
+    width: '100%',
+    maxWidth: '420px',
+
+    '@media (max-width: 1024px)': {
+      alignItems: 'center',
+      textAlign: 'center',
+      maxWidth: '90%'
+    }
+  },
+
+  description: {
+    fontSize: '14px',
+    lineHeight: '20px',
+    textAlign: 'left',
+    '@media (max-width: 1024px)': {
+      textAlign: 'center'
+    }
+  },
+
+  dropdown: {
+    width: '100%'
   }
 }

--- a/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
+++ b/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
-import SubjectsStep from './SubjectsStep'
+import SubjectsStep from '~/containers/tutor-home-page/subjects-step/SubjectsStep'
 import { categoriesMock } from './constants.js'
 import en from '~/constants/translations/en/become-tutor.json'
 
@@ -31,23 +31,23 @@ describe('SubjectsStep component', () => {
     expect(screen.getByTestId('mock-btns-box')).toBeInTheDocument()
   })
 
-  it('shows all categories when Autocomplete is clicked', async () => {
+  it('shows all categories on input focus', async () => {
     await user.click(input)
     const options = await screen.findAllByRole('option')
     expect(options).toHaveLength(categoriesMock.length)
-    categoriesMock.forEach((c, i) => {
-      expect(options[i]).toHaveTextContent(c.name)
+    options.forEach((option, i) => {
+      expect(option).toHaveTextContent(categoriesMock[i].name)
     })
   })
 
-  it('filters categories based on user input', async () => {
+  it('filters categories when typing in input', async () => {
     await user.type(input, 'Math')
     const options = await screen.findAllByRole('option')
     expect(options).toHaveLength(1)
     expect(options[0]).toHaveTextContent('Mathematics')
   })
 
-  it('updates input value when a category is selected', async () => {
+  it('updates input value on category selection', async () => {
     await user.click(input)
     const optionToSelect = await screen.findByText('History')
     await user.click(optionToSelect)

--- a/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
+++ b/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import SubjectsStep from '~/containers/tutor-home-page/subjects-step/SubjectsStep'
-import { categoriesMock } from './constants.js'
+import { categoriesMock } from '~/containers/tutor-home-page/subjects-step/constants.js'
 import en from '~/constants/translations/en/become-tutor.json'
 
 vi.mock('@emotion/react', () => ({

--- a/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
+++ b/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+import SubjectsStep from './SubjectsStep'
+import { categoriesMock } from './constants.js'
+import en from '~/constants/translations/en/become-tutor.json'
+
+vi.mock('@emotion/react', () => ({
+  useTheme: () => ({
+    breakpoints: { down: () => '(max-width:600px)' }
+  })
+}))
+
+const mockBtnsBox = <div data-testid='mock-btns-box'>Mock Buttons</div>
+const t = en.categories
+
+describe('SubjectsStep component', () => {
+  let user, input
+
+  beforeEach(() => {
+    render(<SubjectsStep btnsBox={mockBtnsBox} />)
+    user = userEvent.setup()
+    input = screen.getByRole('combobox', { name: t.mainSubjectsLabel })
+  })
+
+  it('renders all elements correctly', () => {
+    expect(screen.getByText(t.title)).toBeInTheDocument()
+    expect(screen.getByAltText('Study category')).toBeInTheDocument()
+    expect(input).toBeInTheDocument()
+    expect(screen.getByTestId('mock-btns-box')).toBeInTheDocument()
+  })
+
+  it('shows all categories when Autocomplete is clicked', async () => {
+    await user.click(input)
+    const options = await screen.findAllByRole('option')
+    expect(options).toHaveLength(categoriesMock.length)
+    categoriesMock.forEach((c, i) => {
+      expect(options[i]).toHaveTextContent(c.name)
+    })
+  })
+
+  it('filters categories based on user input', async () => {
+    await user.type(input, 'Math')
+    const options = await screen.findAllByRole('option')
+    expect(options).toHaveLength(1)
+    expect(options[0]).toHaveTextContent('Mathematics')
+  })
+
+  it('updates input value when a category is selected', async () => {
+    await user.click(input)
+    const optionToSelect = await screen.findByText('History')
+    await user.click(optionToSelect)
+
+    expect(input).toHaveValue('History')
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+  })
+})

--- a/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
+++ b/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
@@ -4,7 +4,20 @@ import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import SubjectsStep from '~/containers/tutor-home-page/subjects-step/SubjectsStep'
 import { categoriesMock } from '~/containers/tutor-home-page/subjects-step/constants.js'
-import en from '~/constants/translations/en/become-tutor.json'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => {
+      const map = {
+        'becomeTutor.categories.title':
+          'Please choose the main subjects based on the category. You can add others later.',
+        'becomeTutor.categories.mainSubjectsLabel': 'Main Tutoring Category',
+        'becomeTutor.categories.imageAlt': 'Study category'
+      }
+      return map[key]
+    }
+  })
+}))
 
 vi.mock('@emotion/react', () => ({
   useTheme: () => ({
@@ -13,7 +26,6 @@ vi.mock('@emotion/react', () => ({
 }))
 
 const mockBtnsBox = <div data-testid='mock-btns-box'>Mock Buttons</div>
-const t = en.categories
 
 describe('SubjectsStep component', () => {
   let user, input
@@ -21,11 +33,15 @@ describe('SubjectsStep component', () => {
   beforeEach(() => {
     render(<SubjectsStep btnsBox={mockBtnsBox} />)
     user = userEvent.setup()
-    input = screen.getByRole('combobox', { name: t.mainSubjectsLabel })
+    input = screen.getByRole('combobox', { name: 'Main Tutoring Category' })
   })
 
   it('renders all elements correctly', () => {
-    expect(screen.getByText(t.title)).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Please choose the main subjects based on the category. You can add others later.'
+      )
+    ).toBeInTheDocument()
     expect(screen.getByAltText('Study category')).toBeInTheDocument()
     expect(input).toBeInTheDocument()
     expect(screen.getByTestId('mock-btns-box')).toBeInTheDocument()


### PR DESCRIPTION
**Implemented Subjects selection at Subjects Step at stepper.**

**SubjectsStep.jsx:** Created the main component.
- It displays the illustration (imgContainer) and the form (rightBox) in a flex container.
- Uses an Autocomplete (MUI) component to load and select a category from the new constants.js file.
- Correctly positions the btnsBox at the bottom of the view using marginTop: 'auto'.

**SubjectsStep.styles.js:** Added styles for the component.
- Set alignItems: 'stretch' on the main container to ensure the form column (rightBox) stretches to full height, which allows the buttons to be pinned to the bottom.

**SubjectsStep.spec.jsx:** Added unit tests for the component.
- Tests cover initial rendering, opening the Autocomplete, filtering options, and selecting a value.
- Tests are written to be Sonar-compliant (no hardcoded strings, uses mock data for assertions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned subject selection UI with an illustrated left panel and a right-side content area containing a translated title, description, Autocomplete for subjects, and a text input; action buttons remain bottom-aligned.
  * Responsive styling improvements for better mobile/desktop layout and added i18n-enabled labels, placeholders, and accessible image alt text.

* **Tests**
  * Added unit tests for rendering, autocomplete options, filtering, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->