### PR TITLE
feat:#83 implement stepper Subject selection at Subjects Step

### DIFF
--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -6,7 +6,7 @@ import TextField from '@mui/material/TextField'
 
 import { styles } from '~/containers/tutor-home-page/subjects-step/SubjectsStep.styles'
 import img from '~/assets/img/tutor-home-page/become-tutor/study-category.svg'
-import { categoriesMock } from './constants.js'
+import { categoriesMock, subjectsMock } from './constants.js'
 
 const SubjectsStep = ({ btnsBox }) => {
   const { t } = useTranslation()
@@ -27,23 +27,37 @@ const SubjectsStep = ({ btnsBox }) => {
           {t('becomeTutor.categories.title')}
         </Typography>
 
-        <Autocomplete
-          disablePortal
-          getOptionLabel={(option) => option.name}
-          options={categoriesMock}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label={t('becomeTutor.categories.mainSubjectsLabel')}
-              placeholder={t('becomeTutor.categories.mainSubjectsLabel')}
-            />
-          )}
-          sx={styles.dropdown}
-        />
+        <Box sx={styles.dropdownsWrapper}>
+          <Autocomplete
+            disablePortal
+            getOptionLabel={(option) => option.name}
+            options={categoriesMock}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={t('becomeTutor.categories.mainSubjectsLabel')}
+                placeholder={t('becomeTutor.categories.mainSubjectsLabel')}
+              />
+            )}
+            sx={styles.dropdown}
+          />
 
-        <Box mt='auto' sx={{ width: '100%' }}>
-          {btnsBox}
+          <Autocomplete
+            disablePortal
+            getOptionLabel={(option) => option.name}
+            options={subjectsMock}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={t('becomeTutor.categories.subjectLabel')}
+                placeholder={t('becomeTutor.categories.subjectLabel')}
+              />
+            )}
+            sx={styles.dropdown}
+          />
         </Box>
+
+        <Box sx={styles.btnsBoxContainer}>{btnsBox}</Box>
       </Box>
     </Box>
   )

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -3,11 +3,9 @@ import { fadeAnimation } from '~/styles/app-theme/custom-animations'
 export const styles = {
   container: {
     display: 'flex',
-    flexDirection: { xs: 'column', md: 'row' },
-    gap: { xs: '30px', md: '40px' },
-    paddingBottom: { xs: '30px', sm: '0px' },
-    alignItems: { xs: 'center', md: 'stretch' },
-    justifyContent: { xs: 'center', md: 'space-between' },
+    justifyContent: 'space-between',
+    height: { sm: '485px' },
+    paddingBottom: { xs: '30px', sm: '0' },
     ...fadeAnimation
   },
 
@@ -37,7 +35,7 @@ export const styles = {
   },
 
   description: {
-    fontSize: '14px',
+    fontSize: '16px',
     lineHeight: '20px',
     textAlign: { xs: 'center', md: 'left' }
   },

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -32,7 +32,8 @@ export const styles = {
     width: '100%',
     maxWidth: '420px',
     alignItems: { xs: 'center', md: 'flex-start' },
-    textAlign: { xs: 'center', md: 'left' }
+    textAlign: { xs: 'center', md: 'left' },
+    minHeight: { md: '350px' }
   },
 
   description: {
@@ -41,7 +42,19 @@ export const styles = {
     textAlign: { xs: 'center', md: 'left' }
   },
 
+  dropdownsWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '20px',
+    width: '100%'
+  },
+
   dropdown: {
+    width: '100%'
+  },
+
+  btnsBoxContainer: {
+    mt: 'auto',
     width: '100%'
   }
 }

--- a/src/containers/tutor-home-page/subjects-step/constants.js
+++ b/src/containers/tutor-home-page/subjects-step/constants.js
@@ -6,6 +6,18 @@ export const categoriesMock = [
   { name: 'History' }
 ]
 
+export const subjectsMock = [
+  { name: 'Botany' },
+  { name: 'Biochemistry' },
+  { name: 'Genetics' },
+  { name: 'Anatomy' },
+  { name: 'SAT' },
+  { name: 'Zoology' },
+  { name: 'Math' },
+  { name: 'Physics' },
+  { name: 'Chemistry' }
+]
+
 export const languagesMock = [
   { name: 'Chinese' },
   { name: 'Czech' },

--- a/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
+++ b/src/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
@@ -3,7 +3,10 @@ import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 import SubjectsStep from '~/containers/tutor-home-page/subjects-step/SubjectsStep'
-import { categoriesMock } from '~/containers/tutor-home-page/subjects-step/constants.js'
+import {
+  categoriesMock,
+  subjectsMock
+} from '~/containers/tutor-home-page/subjects-step/constants.js'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -12,6 +15,7 @@ vi.mock('react-i18next', () => ({
         'becomeTutor.categories.title':
           'Please choose the main subjects based on the category. You can add others later.',
         'becomeTutor.categories.mainSubjectsLabel': 'Main Tutoring Category',
+        'becomeTutor.categories.subjectLabel': 'Subject',
         'becomeTutor.categories.imageAlt': 'Study category'
       }
       return map[key]
@@ -28,12 +32,13 @@ vi.mock('@emotion/react', () => ({
 const mockBtnsBox = <div data-testid='mock-btns-box'>Mock Buttons</div>
 
 describe('SubjectsStep component', () => {
-  let user, input
+  let user, mainInput, subjectInput
 
   beforeEach(() => {
     render(<SubjectsStep btnsBox={mockBtnsBox} />)
     user = userEvent.setup()
-    input = screen.getByRole('combobox', { name: 'Main Tutoring Category' })
+    mainInput = screen.getByRole('combobox', { name: 'Main Tutoring Category' })
+    subjectInput = screen.getByRole('combobox', { name: 'Subject' })
   })
 
   it('renders all elements correctly', () => {
@@ -43,12 +48,13 @@ describe('SubjectsStep component', () => {
       )
     ).toBeInTheDocument()
     expect(screen.getByAltText('Study category')).toBeInTheDocument()
-    expect(input).toBeInTheDocument()
+    expect(mainInput).toBeInTheDocument()
+    expect(subjectInput).toBeInTheDocument()
     expect(screen.getByTestId('mock-btns-box')).toBeInTheDocument()
   })
 
-  it('shows all categories on input focus', async () => {
-    await user.click(input)
+  it('shows all categories on focus of the main category input', async () => {
+    await user.click(mainInput)
     const options = await screen.findAllByRole('option')
     expect(options).toHaveLength(categoriesMock.length)
     options.forEach((option, i) => {
@@ -56,19 +62,41 @@ describe('SubjectsStep component', () => {
     })
   })
 
-  it('filters categories when typing in input', async () => {
-    await user.type(input, 'Math')
+  it('filters main categories when typing', async () => {
+    await user.type(mainInput, 'Math')
     const options = await screen.findAllByRole('option')
     expect(options).toHaveLength(1)
     expect(options[0]).toHaveTextContent('Mathematics')
   })
 
-  it('updates input value on category selection', async () => {
-    await user.click(input)
+  it('updates main input value on category selection', async () => {
+    await user.click(mainInput)
     const optionToSelect = await screen.findByText('History')
     await user.click(optionToSelect)
-
-    expect(input).toHaveValue('History')
+    expect(mainInput).toHaveValue('History')
     expect(screen.queryByRole('option')).not.toBeInTheDocument()
+  })
+
+  it('shows all subjects on focus of the Subject input', async () => {
+    await user.click(subjectInput)
+    const options = await screen.findAllByRole('option')
+    expect(options).toHaveLength(subjectsMock.length)
+    options.forEach((option, i) => {
+      expect(option).toHaveTextContent(subjectsMock[i].name)
+    })
+  })
+
+  it('filters subjects when typing in the Subject input', async () => {
+    await user.type(subjectInput, 'Bot')
+    const options = await screen.findAllByRole('option')
+    expect(options.length).toBeGreaterThan(0)
+    expect(options[0].textContent.toLowerCase()).toContain('bot')
+  })
+
+  it('updates Subject input value on selection', async () => {
+    await user.click(subjectInput)
+    const optionToSelect = await screen.findByText(subjectsMock[0].name)
+    await user.click(optionToSelect)
+    expect(subjectInput).toHaveValue(subjectsMock[0].name)
   })
 })


### PR DESCRIPTION
Implemented Subject selection step in the stepper, updated styles for correct layout, and updated tests for rendering, filtering, and selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a subject selection autocomplete to the tutor setup with predefined subject options.
  * Action buttons repositioned to appear below the subject field.
  * Page layout and spacing updated to fit the new field; description text slightly larger for readability.

* **Tests**
  * Added tests covering subject input rendering, filtering, focus behavior, and selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->